### PR TITLE
Correct backtick and escape

### DIFF
--- a/nats-streaming-concepts/channels/README.md
+++ b/nats-streaming-concepts/channels/README.md
@@ -2,7 +2,7 @@
 
 Channels are at the heart of the NATS Streaming Server. Channels are subjects clients send data to and consume from.
 
-_**Note: NATS Streaming server does not support wildcard for channels, that is, one cannot subscribe on \`foo.**_**`, or`&gt;\`, etc...\***
+_**Note: NATS Streaming server does not support wildcard for channels, that is, one cannot subscribe on `foo.*`, or `foo.>`, etc...**_
 
 The number of channels can be limited \(and is by default\) through configuration. Messages produced to a channel are stored in a message log inside this channel.
 


### PR DESCRIPTION
I noticed some error in the markdown rendering in https://docs.nats.io/nats-streaming-concepts/channels