### PR TITLE
[ADDED] Missing `credentials` config param

### DIFF
--- a/nats-streaming-server/configuring/cfgfile.md
+++ b/nats-streaming-server/configuring/cfgfile.md
@@ -73,6 +73,7 @@ In general the configuration parameters are the same as the command line argumen
 | encrypt | Specify if server should encrypt messages \(only the payload\) when storing them | `true` or `false` | `encrypt: true` |
 | encryption\_cipher | Cipher to use for encryption. Currently support AES and CHAHA \(ChaChaPoly\). Defaults to AES | `AES` or `CHACHA` | `encryption_cipher: "AES"` |
 | encryption\_key | Encryption key. It is recommended to specify the key through the `NATS_STREAMING_ENCRYPTION_KEY` environment variable instead | String | `encryption_key: "mykey"` |
+| credentials | Credentials file to connect to external NATS 2.0+ Server  | String | `credentials: "streaming_server.creds"` |
 
 ## TLS Configuration
 


### PR DESCRIPTION
The `credentials` configuration parameter was missing from the table