### PR TITLE
Fix for GitBook rendering different tab indents

### DIFF
--- a/developing-with-nats/receiving/structure.md
+++ b/developing-with-nats/receiving/structure.md
@@ -8,13 +8,13 @@ For example, to receive JSON you could do:
 {% tab title="Go" %}
 ```go
 nc, err := nats.Connect("demo.nats.io",
-        nats.ErrorHandler(func(nc *nats.Conn, s *nats.Subscription, err error) {
-	    if s != nil {
-		log.Printf("Async error in %q/%q: %v", s.Subject, s.Queue, err)
-	    } else {
-		log.Printf("Async error outside subscription: %v", err)
-	    }
-        }))
+    nats.ErrorHandler(func(nc *nats.Conn, s *nats.Subscription, err error) {
+        if s != nil {
+        log.Printf("Async error in %q/%q: %v", s.Subject, s.Queue, err)
+        } else {
+        log.Printf("Async error outside subscription: %v", err)
+        }
+    }))
 if err != nil {
     log.Fatal(err)
 }


### PR DESCRIPTION
Convert tabs to whitespace assuming tab-stops of 4 not 8.  Serves me right for preserving existing style instead of just playing safe.