### PR TITLE
Fix missing 'nats-io/' in a URL

### DIFF
--- a/nats-tools/mkpasswd.md
+++ b/nats-tools/mkpasswd.md
@@ -9,7 +9,7 @@ A utility for creating `bcrypt` hashes is included with the nats-server distribu
 If you have [go installed](https://golang.org/doc/install), you can easily install the `mkpasswd` tool by doing:
 
 ```text
-> go get github.com/nats-server/util/mkpasswd
+> go get github.com/nats-io/nats-server/util/mkpasswd
 ```
 
 Alternatively, you can:


### PR DESCRIPTION
Reported on Slack by https://github.com/rchenzheng