### PR TITLE
Updates for NATS Streaming v0.17.0 release

### DIFF
--- a/nats-streaming-concepts/monitoring/endpoints.md
+++ b/nats-streaming-concepts/monitoring/endpoints.md
@@ -9,18 +9,22 @@ The endpoint [http://localhost:8222/streaming/serverz](http://localhost:8222/str
 ```text
 {
   "cluster_id": "test-cluster",
-  "server_id": "JEzjfVQS4JIEzM7lZmWHm9",
-  "version": "0.14.2",
-  "go": "go1.11.10",
+  "server_id": "h5MPY4SfSbqRnyk7Omgr35",
+  "version": "0.17.0",
+  "go": "go1.13.7",
   "state": "STANDALONE",
-  "now": "2019-05-21T11:09:35.364637-06:00",
-  "start_time": "2019-05-21T11:09:24.204869-06:00",
-  "uptime": "11s",
+  "now": "2020-02-11T16:17:33.101243-07:00",
+  "start_time": "2020-02-11T16:17:15.323466-07:00",
+  "uptime": "17s",
   "clients": 0,
   "subscriptions": 0,
   "channels": 0,
   "total_msgs": 0,
-  "total_bytes": 0
+  "total_bytes": 0,
+  "in_msgs": 0,
+  "in_bytes": 0,
+  "out_msgs": 0,
+  "out_bytes": 0
 }
 ```
 
@@ -29,19 +33,23 @@ In clustering mode, there is an additional field that indicates the RAFT role of
 ```text
 {
   "cluster_id": "test-cluster",
-  "server_id": "t9W9zbOIIi5Y9Guppxl0lF",
-  "version": "0.14.2",
-  "go": "go1.11.10",
+  "server_id": "UaHeX4HdFN57e63ULcifHQ",
+  "version": "0.17.0",
+  "go": "go1.13.7",
   "state": "CLUSTERED",
-  "role": "Follower",
-  "now": "2019-05-21T11:10:15.765261-06:00",
-  "start_time": "2019-05-21T11:10:12.21284-06:00",
-  "uptime": "3s",
+  "role": "Leader",
+  "now": "2020-02-11T16:19:30.761192-07:00",
+  "start_time": "2020-02-11T16:19:24.777221-07:00",
+  "uptime": "5s",
   "clients": 0,
   "subscriptions": 0,
   "channels": 0,
   "total_msgs": 0,
-  "total_bytes": 0
+  "total_bytes": 0,
+  "in_msgs": 0,
+  "in_bytes": 0,
+  "out_msgs": 0,
+  "out_bytes": 0
 }
 ```
 

--- a/nats-streaming-server/configuring/cfgfile.md
+++ b/nats-streaming-server/configuring/cfgfile.md
@@ -84,6 +84,8 @@ Note that the Streaming Server uses a connection to a NATS Server, and so the NA
 | client\_cert | Client key for the streaming server | File path | `client_cert: "/path/to/client/cert_file"` |
 | client\_key | Client certificate for the streaming server | File path | `client_key: "/path/to/client/key_file"` |
 | client\_ca | Client certificate CA for the streaming server | File path | `client_ca: "/path/to/client/ca_file"` |
+| server\_name | Expected hostname returned in the NATS Server certificate | String | `server_name: "theserverhostname"` |
+| insecure | Skips the NATS server's certificate chain and host name verification. Should not be used in production | `true` or `false` (default `false`) | `insecure: true` |
 
 ## Store Limits Configuration
 

--- a/nats-streaming-server/configuring/cmdline.md
+++ b/nats-streaming-server/configuring/cmdline.md
@@ -32,7 +32,7 @@ Streaming Server Options:
     -sl,  --signal <signal>[=<pid>]      Send signal to nats-streaming-server process (stop, quit, reopen)
           --encrypt <bool>               Specify if server should use encryption at rest
           --encryption_cipher <string>   Cipher to use for encryption. Currently support AES and CHAHA (ChaChaPoly). Defaults to AES
-          --encryption_key <sting>       Encryption Key. It is recommended to specify it through the NATS_STREAMING_ENCRYPTION_KEY environment variable instead
+          --encryption_key <string>      Encryption Key. It is recommended to specify it through the NATS_STREAMING_ENCRYPTION_KEY environment variable instead
 
 Streaming Server Clustering Options:
     --clustered <bool>                   Run the server in a clustered configuration (default: false)
@@ -72,7 +72,8 @@ Streaming Server SQL Store Options:
     --sql_max_open_conns <int>       Maximum number of opened connections to the database
 
 Streaming Server TLS Options:
-    -secure <bool>                   Use a TLS connection to the NATS server without verification; weaker than specifying certificates.
+    -secure <bool>                   Use a TLS connection to the NATS server without
+                                     verification; weaker than specifying certificates.
     -tls_client_key <string>         Client key for the streaming server
     -tls_client_cert <string>        Client certificate for the streaming server
     -tls_client_cacert <string>      Client certificate CA for the streaming server
@@ -120,6 +121,6 @@ NATS Clustering Options:
 Common Options:
     -h, --help                       Show this message
     -v, --version                    Show version
-        --help_tls                   TLS help
+        --help_tls                   TLS help.
 ```
 


### PR DESCRIPTION
- Added some configuration params in TLS section
- Updated serverz monitoring endpoint with new fields
- Not related to this release, but bring up-to-date list of command
  line parameters (result from "nats-streaming-server -h")

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>