### PR TITLE
Reworded and merged authorization map.

### DIFF
--- a/nats-server/configuration/securing_nats/README.md
+++ b/nats-server/configuration/securing_nats/README.md
@@ -3,5 +3,5 @@
 The NATS server provides several forms of security:
 
 * Connections can be [_encrypted_ with TLS](tls.md)
-* Client connections can require [_authentication_](auth_intro/)
+* Client connections can require [_authentication_](auth_intro/README.md)
 * Clients can require [_authorization_](authorization.md) for subjects they publish or subscribe to

--- a/nats-server/configuration/securing_nats/authorization.md
+++ b/nats-server/configuration/securing_nats/authorization.md
@@ -25,7 +25,7 @@ The `permission` map provides additional properties for configuring a `permissio
 | `allow` | List of subject names that are allowed to the client |
 | `deny` | List of subjects that are denied to the client |
 
-**Important Note** It is important to not break request/reply patterns. In some cases \(as shown below\) you need to add rules as above with Alice and Bob for the `_INBOX.>` pattern. If an unauthorized client publishes or attempts to subscribe to a subject that has not been _allow listed_, the action fails and is logged at the server, and an error message is returned to the client. The [allow responses](#allow-responses-map) option can simplify this.
+**Important Note** It is important to not break request/reply patterns. In some cases \(as shown [below](#variables)\) you need to add rules for the `_INBOX.>` pattern. If an unauthorized client publishes or attempts to subscribe to a subject that has not been _allow listed_, the action fails and is logged at the server, and an error message is returned to the client. The [allow responses](#allow-responses-map) option can simplify this.
 
 ## Allow Responses Map
 

--- a/nats-server/configuration/securing_nats/authorization.md
+++ b/nats-server/configuration/securing_nats/authorization.md
@@ -4,7 +4,7 @@ The NATS server supports authorization using subject-level permissions on a per-
 
 Each permission specifies the subjects the user can publish to and subscribe to. The parser is generous at understanding what the intent is, so both arrays and singletons are processed. For more complex configuration, you can specify a `permission` object which explicitly allows or denies subjects. The specified subjects can specify wildcards as well. Permissions can make use of [variables](../README.md#variables).
 
-A special field inside the authorization map is `default_permissions`. When present, it contains permissions that apply to user that do not have permissions associated with them.
+A special field inside the authorization map is `default_permissions`. When present, it contains permissions that apply to users that do not have permissions associated with them.
 
 ## Permissions Configuration Map
 

--- a/nats-server/configuration/securing_nats/authorization.md
+++ b/nats-server/configuration/securing_nats/authorization.md
@@ -2,9 +2,9 @@
 
 The NATS server supports authorization using subject-level permissions on a per-user basis. Permission-based authorization is available with multi-user authentication via the `users` list.
 
-Each permission specifies the subjects the user can publish to and subscribe to. The parser is generous at understanding what the intent is, so both arrays and singletons are processed. For more complex configuration, you can specify a `permission` object which explicitly allows or denies subjects. The specified subjects can specify wildcards. Permissions can make use of [variables](../README.md#variables).
+Each permission specifies the subjects the user can publish to and subscribe to. The parser is generous at understanding what the intent is, so both arrays and singletons are processed. For more complex configuration, you can specify a `permission` object which explicitly allows or denies subjects. The specified subjects can specify wildcards as well. Permissions can make use of [variables](../README.md#variables).
 
-You configure authorization by creating a `permissions` entry in the `authorization` object.
+A special field inside the authorization map is `default_permissions`. When present, it contains permissions that apply to user that do not have permissions associated with them.
 
 ## Permissions Configuration Map
 
@@ -12,21 +12,20 @@ The `permissions` map specify subjects that can be subscribed to or published by
 
 | Property | Description |
 | :--- | :--- |
-| `publish` | subject, list of subjects, or permission map the client can publish |
-| `subscribe` | subject, list of subjects, or permission map the client can subscribe |
-| `allow_responses` | boolean or object |
-
+| `publish` | subject, list of subjects, or [permission map](#permission-map) the client can publish |
+| `subscribe` | subject, list of subjects, or [permission map](#permission-map) the client can subscribe to. In this context it is possible to provide an optional queue name: `<subject> <queue>` to express queue group permissions. These permissions can also use wildcards such as `v2.*` or `>`.|
+| `allow_responses` | boolean or [responses map](#allow-responses-map), default is `false` |
 
 ## Permission Map
 
-The `permission` map provides additional properties for configuring a `permissions` map. Instead of providing a list of subjects that are allowed, the `permission` map allows you to explicitly list subjects you want to`allow` or `deny`:
+The `permission` map provides additional properties for configuring a `permissions` map. Instead of providing a list of allowable subjects and optional queues, the `permission` map allows you to explicitly list those you want to`allow` or `deny`. Both lists can be provided. In case of overlap `deny` has priority.
 
 | Property | Description |
 | :--- | :--- |
 | `allow` | List of subject names that are allowed to the client |
 | `deny` | List of subjects that are denied to the client |
 
-**Important Note** NATS Authorizations can be _allow lists_, _deny lists_, or both. It is important to not break request/reply patterns. In some cases \(as shown below\) you need to add rules as above with Alice and Bob for the `_INBOX.>` pattern. If an unauthorized client publishes or attempts to subscribe to a subject that has not been _allow listed_, the action fails and is logged at the server, and an error message is returned to the client.
+**Important Note** It is important to not break request/reply patterns. In some cases \(as shown below\) you need to add rules as above with Alice and Bob for the `_INBOX.>` pattern. If an unauthorized client publishes or attempts to subscribe to a subject that has not been _allow listed_, the action fails and is logged at the server, and an error message is returned to the client. The [allow responses](#allow-responses-map) option can simplify this.
 
 ## Allow Responses Map
 
@@ -35,19 +34,25 @@ When set to `true`, only one response is allowed, meaning the permission to publ
 
 | Property | Description |
 | :--- | :--- |
-|  `max` | The maximum number of response messages that can be published. |
+| `max` | The maximum number of response messages that can be published. |
 | `expires` | The amount of time the permission is valid. Values such as `1s`, `1m`, `1h` (1 second, minute, hour) etc can be specified. Default doesn't have a time limit. |
 
 When `allow_responses` is set to `true`, it defaults to the equivalent of `{ max: 1 }` and no time limit.
 
 **Important Note** When using `nsc` to configure your users, you can specify the `--allow-pub-response` and `--response-ttl` to control these settings.
 
-## Example
+## Examples
+
+### Variables
 
 Here is an example authorization configuration that uses _variables_ which defines four users, three of whom are assigned explicit permissions.
 
 ```text
 authorization {
+  default_permissions = {
+    publish = "SANDBOX.*"
+    subscribe = ["PUBLIC.>", "_INBOX.>"]
+  }
   ADMIN = {
     publish = ">"
     subscribe = ">"
@@ -60,10 +65,6 @@ authorization {
     subscribe = ["req.a", "req.b"]
     publish = "_INBOX.>"
   }
-  DEFAULT_PERMISSIONS = {
-    publish = "SANDBOX.*"
-    subscribe = ["PUBLIC.>", "_INBOX.>"]
-  }
   users = [
     {user: admin,   password: $ADMIN_PASS, permissions: $ADMIN}
     {user: client,  password: $CLIENT_PASS, permissions: $REQUESTOR}
@@ -73,16 +74,18 @@ authorization {
 }
 ```
 
-> _DEFAULT\_PERMISSIONS_ is a special permissions name. If defined, it applies to all users that don't have specific permissions set.
+ > `default_permissions` is a special entry. If defined, it applies to all users that don't have specific permissions set.
 
 * _admin_ has `ADMIN` permissions and can publish/subscribe on any subject. We use the wildcard `>` to match any subject.
 * _client_ is a `REQUESTOR` and can publish requests on subjects `req.a` or `req.b`, and subscribe to anything that is a response \(`_INBOX.>`\).
 * _service_ is a `RESPONDER` to `req.a` and `req.b` requests, so it needs to be able to subscribe to the request subjects and respond to client's that can publish requests to `req.a` and `req.b`. The reply subject is an inbox. Typically inboxes start with the prefix `_INBOX.` followed by a generated string. The `_INBOX.>` subject matches all subjects that begin with `_INBOX.`.
-* _other_ has no permissions granted and therefore inherits the default permission set. You set the inherited default permissions by assigning them to the `default_permissions` entry inside of the authorization configuration block.
+* _other_ has no permissions granted and therefore inherits the default permission set. 
 
 > Note that in the above example, any client with permissions to subscribe to `_INBOX.>` can receive _all_ responses published. More sensitive installations will want to add or subset the prefix to further limit subjects that a client can subscribe. Alternatively, [_Accounts_](auth_intro/accounts.md) allow complete isolation limiting what members of an account can see.
 
-Here's another example, where the `allow` and `deny` options are specified:
+### Allow/Deny Specified
+
+Here's an example without variables, where the `allow` and `deny` options are specified:
 
 ```text
 authorization: {
@@ -111,6 +114,8 @@ authorization: {
 }
 ```
 
+### allow_responses
+
 Here's an example with `allow_responses`:
 
 ```text
@@ -125,28 +130,20 @@ authorization: {
 
 User `a` has no restrictions. User `b` can listen on `q` for requests and can only publish once to reply subjects. All other subjects will be denied. User `c` can also listen on `q` for requests, but is able to return at most 5 reply messages, and the reply subject can be published at most for `1` minute.
 
-## Queue Permissions
+### Queue Permissions
 
-Added in NATS Server v2.1.2, Queue Permissions allow you to express authorization for queue groups. As queue groups are integral to implementing horizontally scalable microservices, control of who is allowed to join a specific queue group is important to the overall security model.
-
-A Queue Permission can be defined with the syntax `<subject> <queue>`, where the name of the queue can also use wildcards, for example the following would allow clients to join queue groups v1 and v2.\*, but won't allow plain subscriptions:
-
-```text
-allow = ["foo v1", "foo v2.*"]
-```
-
-The full wildcard can also be used, for example the following would prevent plain subscriptions on `bar` but allow the client to join any queue:
-
-```text
-allow = ["bar >"]
-```
-
-Permissions for Queue Subscriptions can be combined with plain subscriptions as well though, for example you could allow plain subscriptions on `foo` but constrain the queues to which a client can join, as well as preventing any service from using a queue subscription with the name `*.prod`:
+User `a` can ony subscribe to `foo` as part of the queue subscriptions `queue`. User `b` has permissions for queue subscriptions as well as plain subscriptions. You can allow plain subscriptions on `foo` but constrain the queues to which a client can join, as well as preventing any service from using a queue subscription with the name `*.prod`:
 
 ```text
 users = [
   {
-    user: "foo", permissions: {
+    user: "a", permissions: {
+      sub: {
+        allow: ["foo queue"]
+     }
+  }
+  {
+    user: "b", permissions: {
       sub: {
         # Allow plain subscription foo, but only v1 groups or *.dev queue groups
         allow: ["foo", "foo v1", "foo v1.>", "foo *.dev"]


### PR DESCRIPTION
An attempt at integrating queue permissions.
default_permissions is not a variable, hence changed the example


Signed-off-by: Matthias Hanel <mh@synadia.com>