### PR TITLE
Clustering: add note about horizontal scalability

### DIFF
--- a/nats-streaming-concepts/clustering/README.md
+++ b/nats-streaming-concepts/clustering/README.md
@@ -1,6 +1,6 @@
 # Clustering
 
-NATS Streaming Server supports clustering and data replication, implemented with the [Raft consensus algorithm](https://raft.github.io/), for the purposes of high availability.
+NATS Streaming Server supports clustering and data replication, implemented with the [Raft consensus algorithm](https://raft.github.io/), for the purposes of high availability. It provides protection for some of the nodes in the cluster failing, but since the leader is handling all incoming data from publishers and outgoing data to subscribers, it is not horizontally scalable. The cluster size should probably be limited to 3 to 5 nodes (RAFT recommends an odd number of nodes).
 
 There are two ways to bootstrap a cluster: with an explicit cluster configuration or with "auto" configuration using a seed node. With the first, we provide the IDs of the nodes participating in the cluster. In this case, the participating nodes will elect a leader. With the second, we start one server as a seed node, which will elect itself as leader, and subsequent servers will automatically join the seed \(note that this also works with the explicit cluster configuration once the leader has been established\). With the second method, we need to be careful to avoid starting multiple servers as seed as this will result in a split-brain. Both of these configuration methods are shown in the sections below.
 


### PR DESCRIPTION
Since NATS Streaming implementation is such as the leader is the one handling all communication with clients, adding a note that the cluster cannot be horizontally scaled, and that its size should be limited to 3 to 5 nodes.