### PR TITLE
tls chagnes

### DIFF
--- a/nats-server/configuration/securing_nats/auth_intro/tls_mutual_auth.md
+++ b/nats-server/configuration/securing_nats/auth_intro/tls_mutual_auth.md
@@ -8,7 +8,6 @@ The server can require TLS certificates from a client. When needed, you can use 
 > Note: To simplify the common scenario of maintainers looking at the monitoring endpoint, `verify` and `verify_and_map` do not apply to the monitoring port.
 
 The examples in the following sections make use of the certificates you [generated](../tls.md#Self-Signed-Certificates-for-Testing) locally.
-For simplicity it is assumed that you copied `rootCA.pem` into the same folder where the certificates are generated in and you start `nats-server`.
 
 ## Validating a Client Certificate
 

--- a/nats-server/configuration/securing_nats/tls.md
+++ b/nats-server/configuration/securing_nats/tls.md
@@ -88,7 +88,7 @@ While this works for server and libraries from the NATS eco system, you will exp
 Another option is to configure your system's trust store to include self signed certificate(s).
 Which trust store needs to be configured depends on what you are testing.
 * This may be your OS for server and certain clients.
-* The runtime environment for other clients like Java or Python.
+* The runtime environment for other clients like Java, Python or Node.js.
 * Your browser for monitoring endpoints and websockets.
 
 Please check your system's documentation on how to trust a particular self signed certificate.
@@ -103,15 +103,14 @@ Meaning, if a client/browser/server connect via tls to `127.0.0.1`, the server n
 
 The simplest way to generate a CA as well as client and server certificates is [mkcert](https://github.com/FiloSottile/mkcert).
 This zero config tool generates and installs the CA into your **local** system trust store(s) and makes providing SAN straight forward. 
-Here is an example:
+Check it's [documentation](https://github.com/FiloSottile/mkcert/blob/master/README.md) for installation and your system's trust store. 
+Here is a simple example:
 
-Generate a CA and output the location of the root CA cert file `rootCA.pem`. 
-Next generate a certificate, valid for use by `localhost` and the IP `::1`(`-cert-file` and `-key-file` overwrite default file names).
+Generate a CA as well as a certificate, valid for use by `localhost` and the IP `::1`(`-cert-file` and `-key-file` overwrite default file names).
 Then start a nats server using the generated certificate.
 
 ```bash
 mkcert -install
-mkcert -CAROOT
 mkcert -cert-file server-cert.pem -key-file server-key.pem localhost ::1
 nats-server --tls --tlscert=server-cert.pem --tlskey=server-key.pem -ms 8222
 ```
@@ -128,6 +127,14 @@ Also add a SAN email for usage as user name in `verify_and_map`.
 
 ```bash
 mkcert -client -cert-file client-cert.pem -key-file client-key.pem localhost ::1 email@localhost
+```
+
+Examples in this document make use of the certificates generated so far. 
+To simplify examples using the CA certificate, copy `rootCA.pem` into the same folder where the certificates were generated.
+To obtain the CA certificate's location use this command:
+
+```bash
+mkcert -CAROOT
 ```
 
 Once you are done testing, remove the CA from your **local** system trust store(s).

--- a/nats-server/configuration/securing_nats/tls.md
+++ b/nats-server/configuration/securing_nats/tls.md
@@ -4,15 +4,15 @@ The NATS server uses modern TLS semantics to encrypt client, route, and monitori
 
 | Property | Description |
 | :--- | :--- |
-| `ca_file` | TLS certificate authority file. |
 | `cert_file` | TLS certificate file. |
+| `key_file` | TLS certificate key file. |
+| `ca_file` | TLS certificate authority file. When not present, default to the system trust store. |
 | `cipher_suites` | When set, only the specified TLS cipher suites will be allowed. Values must match the golang version used to build the server. |
 | `curve_preferences` | List of TLS cipher curves to use in order. |
-| `insecure` | Skip certificate verification. |
-| `key_file` | TLS certificate key file. |
-| `timeout` | TLS handshake timeout in fractional seconds. Default set to 2 seconds. |
-| `verify_and_map` | If `true`, require and verify client certificates and map certificate values for authentication purposes. |
-| `verify` | If `true`, require and verify client certificates. |
+| `insecure` | Skip certificate verification. **NOT Recommended** |
+| `timeout` | TLS handshake [timeout](#TLS-Timeout) in fractional seconds. Default set to `0.5` seconds. |
+| `verify` | If `true`, require and [verify](auth_intro/tls_mutual_auth.md#Validating-a-Client-Certificate) client certificates. To support use by Browser, this option does not apply to monitoring. |
+| `verify_and_map` | If `true`, require and verify client certificates and [map](auth_intro/tls_mutual_auth.md#Mapping-Client-Certificates-To-A-User) certificate values for authentication purposes. Does not apply to monitoring either. |
 
 The simplest configuration:
 
@@ -59,3 +59,90 @@ tls: {
 }
 ```
 
+## Self Signed Certificates for Testing
+
+Explaining [Public key infrastructure](https://en.wikipedia.org/wiki/Public_key_infrastructure), [Certificate Authorities (CA)](https://en.wikipedia.org/wiki/Certificate_authority) and [x509](https://tools.ietf.org/html/rfc5280) [certificates](https://en.wikipedia.org/wiki/Public_key_certificate) fall well outside the scope of this document. 
+So does an explanation on how to obtain a properly trusted certificates.
+
+If anybody outside your organization needs to connect, get certs from a public certificate authority. 
+Think carefully about revocation and cycling times, as well as automation, when picking a CA. 
+If arbitrary applications inside your organization need to connect, use a cert from your in-house CA. 
+If only resources inside a specific environment need to connect, that environment might have its own dedicated automatic CA, eg in Kubernetes clusters, so use that.
+
+**Only** for **testing** purposes does it makes sense to generate self signed certificates, even your own CA. 
+This is a **short** guide on how to do just that and what to watch out for.
+
+> **DO NOT USE these certificates in production!!!**
+
+### Problems With Self Signed Certificates
+
+#### Missing in Relevant Trust Stores 
+
+As they should, these are **not trusted** by the system your server or clients are running on.
+
+One option is to specify the CA in every client you are using.
+In case you make use of `verify` and `verify_and_map` you need to specify `ca_file` in the server.
+If you are having a more complex setup involving cluster, gateways or leaf nodes, `ca_file` needs to be present in `tls` maps used to connect to the server with self signed certificates. 
+While this works for server and libraries from the NATS eco system, you will experience issues when connecting with other tools such as your Browser.
+
+Another option is to configure your system's trust store to include self signed certificate(s).
+Which trust store needs to be configured depends on what you are testing.
+* This may be your OS for server and certain clients.
+* The runtime environment for other clients like Java or Python.
+* Your browser for monitoring endpoints and websockets.
+
+Please check your system's documentation on how to trust a particular self signed certificate.
+
+#### Missing Subject Alternative Name 
+
+Another common problem is failed [identity validation](https://tools.ietf.org/html/rfc6125).
+The IP or DNS name to connect to needs to match a [Subject Alternative Name (SAN)](https://tools.ietf.org/html/rfc4985) inside the certificate.
+Meaning, if a client/browser/server connect via tls to `127.0.0.1`, the server needs to present a certificate with a SAN containing the IP `127.0.0.1` or the connection will be closed with a handshake error.
+
+### Creating Self Signed Certificates for Testing
+
+The simplest way to generate a CA as well as client and server certificates is [mkcert](https://github.com/FiloSottile/mkcert).
+This zero config tool generates and installs the CA into your **local** system trust store(s) and makes providing SAN straight forward. 
+Here is an example:
+
+Generate a CA and output the location of the root CA cert file `rootCA.pem`. 
+Next generate a certificate, valid for use by `localhost` and the IP `::1`(`-cert-file` and `-key-file` overwrite default file names).
+Then start a nats server using the generated certificate.
+
+```bash
+mkcert -install
+mkcert -CAROOT
+mkcert -cert-file server-cert.pem -key-file server-key.pem localhost ::1
+nats-server --tls --tlscert=server-cert.pem --tlskey=server-key.pem -ms 8222
+```
+
+Now you should be able to access the monitoring endpoint `https://localhost:8222` with your browser.  
+`https://127.0.0.1:8222` however should result in an error as `127.0.0.1` is not listed as SAN.
+You will not be able to establish a connection from another computer either. 
+For that to work you have to provide appropriate DNS and/or IP [SAN(s)](#Missing-Subject-Alternative-Name)
+
+To generate certificates that work with `verify` provide the `-client` option.
+This will cause it to add an appropriate key usage for client authentication.
+Please note that client refers to connecting process, not necessarily a NATS client.
+Also add a SAN email for usage as user name in `verify_and_map`. 
+
+```bash
+mkcert -client -cert-file client-cert.pem -key-file client-key.pem localhost ::1 email@localhost
+```
+
+Once you are done testing, remove the CA from your **local** system trust store(s).
+
+```
+mkcert -uninstall
+```
+
+Alternatively, you can also use [openssl](https://www.openssl.org/) to [generate certificates](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs). 
+This tool allows a lot more customization of the generated certificates. 
+It is a lot **more complex** and does **not manage** installation into the system trust store(s).
+
+However, for inspecting certificates it is quite handy. To inspect the certificates from the above example execute these commands:
+
+```bash
+openssl x509 -noout -text -in server-cert.pem
+openssl x509 -noout -text -in client-cert.pem
+```


### PR DESCRIPTION
Add a section on cert generation. (got Phil's input and ok)

Move from test certificates to generated ones. 
(Will do that for the client in a separate step. Java complicates things)

Mention verify, verify_and_map and monitoring.
Mention order in which user name is found in certs.

Signed-off-by: Matthias Hanel <mh@synadia.com>