### PR TITLE
Monitoring and logging changes.

### DIFF
--- a/nats-server/configuration/README.md
+++ b/nats-server/configuration/README.md
@@ -113,9 +113,9 @@ authorization: {
 | `listen` | Listen specification `<host>:<port>` for client connections. Either use this or the options `host` and/or `port`.  | same as `host`, `port` |
 | `client_advertise`| Alternative client listen specification `<host>:<port>` or just `<host>` to advertise to clients and other server. Useful in [cluster](clustering/cluster_config.md) setups with NAT. | Advertise what `host` and `port` specify.  |
 | [`tls`](securing_nats/tls.md) | Configuration map for tls for client and http monitoring. | |
-| [`cluster`](clustering/cluster_config.md) | Configuration map for [cluster](clustering/README.md) configuration. | |
-| [`gateway`](gateways/gateway.md) | Configuration map for [Gateway](gateways/README.md) configuration. | |
-| [`leafnode`](leafnodes/leafnode_conf.md) | Configuration map for [leafnode](leafnodes/README.md). ||
+| [`cluster`](clustering/cluster_config.md) | Configuration map for [cluster](clustering/README.md). | |
+| [`gateway`](gateways/gateway.md#Gateway-Configuration-Block) | Configuration map for [gateway](gateways/README.md). | |
+| [`leafnode`](leafnodes/leafnode_conf.md) | Configuration map for a [leafnode](leafnodes/README.md). ||
 
 ### Connection Timeouts
 | Property | Description | Default |
@@ -141,7 +141,7 @@ authorization: {
 | [`accounts`](securing_nats/accounts.md) | Configuration map for accounts. | |
 | [`resolver`](../../nats-tools/nas/README.md) | Resolver type `MEMORY` or `URL(<url>)` for account JWTs.  |  |
 | `resolver_tls` | [`tls` configuration map](securing_nats/tls.md) for tls connections to the resolver. (This is for an outgoing connection and therefore does not use `timeout`, `verify` and `map_and_verify`)    |  |
-| `resolver_preload` | Map to preload account public keys and their corresponding JWT. Keys consist of `<account public nkey>`, value is the `<corresponding jwt>`. | |
+| `resolver_preload` | Map to preload account public keys and their corresponding JWT. Keys consist of `<account public nkey>`, value is the `<corresponding jwt>`. Only used when `resolver=MEMORY`. | |
 | `system_account` | Name of the system account. See [System Accounts](../nats_admin/sys_accounts/README.md) for more details. | |
 
 ### Runtime Configuration
@@ -154,14 +154,15 @@ authorization: {
 | Property | Description | Default |
 | :--- | :--- | :--- |
 | `server_name`| The servers name, shows up in logging. Defaults to the server's id. | Generated Server ID |
-| `trace` | If `true` enable protocol trace log messages | `false`, disabled |
+| `trace` | If `true` enable protocol trace log messages. Excludes the system account. | `false`, disabled |
+| `trace_verbose` | If `true` enable protocol trace log messages. Includes the system account. | `false`, disabled |
 | `debug` | If `true` enable debug log messages | `false`, disabled |
 | `logtime` | If set to `false`, log without timestamps | `true`, include timestamp|
 | `log_file` | Log file name, relative to... | No log file |
-| `log_size_limit` | Size in bytes after the log file rolls over to a new one  | `0`, unlimited |
+| [`log_size_limit`](logging.md#log-rotation) | Size in bytes after the log file rolls over to a new one  | `0`, unlimited |
 | `max_traced_msg_len` | Set a limit to the trace of the payload of a message. | `0`, unlimited | 
 | `syslog` | Log to syslog. | `false`, disabled |
-| `remote_syslog` |  Syslog server address.|  |
+| `remote_syslog` | [Syslog server](logging.md#syslog) address.|  |
 | [`http_port`](monitoring.md) | http port for server monitoring. |  |
 | [`http`](monitoring.md) | Listen specification `<host>:<port>`for server monitoring. |  |
 | [`https_port`](monitoring.md) | https port for server monitoring. This is influenced by the tls property. |  |

--- a/nats-server/configuration/logging.md
+++ b/nats-server/configuration/logging.md
@@ -15,7 +15,9 @@ The following logging operations are supported:
 -r, --remote_syslog              Syslog server address.
 -D, --debug                      Enable debugging output.
 -V, --trace                      Trace the raw protocol.
+-VV                              Verbose trace (traces system account as well)
 -DV                              Debug and Trace.
+-DVV                             Debug and verbose trace (traces system account as well)
 ```
 
 #### Debug and trace
@@ -41,7 +43,7 @@ If `-T false` then log entries are not timestamped. Default is true.
 You can configure syslog with `UDP`:
 
 ```bash
-nats-server -s udp://localhost:514
+nats-server -r udp://localhost:514
 ```
 
 or `syslog:`

--- a/nats-server/configuration/monitoring.md
+++ b/nats-server/configuration/monitoring.md
@@ -13,7 +13,7 @@ To monitor the NATS messaging system, `nats-server` provides a lightweight HTTP 
 
 All endpoints return a JSON object.
 
-The NATS monitoring endpoints support [JSONP](https://en.wikipedia.org/wiki/JSONP) and [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing#How_CORS_works), making it easy to create single page monitoring web applications. Part of the NATS eco system is a tool called [nats-top](../../nats-tools/nats_top/README.md) that visualizes data from these endpoints on the command line.
+The NATS monitoring endpoints support [JSONP](https://en.wikipedia.org/wiki/JSONP) and [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing#How_CORS_works), making it easy to create single page monitoring web applications. Part of the NATS ecosystem is a tool called [nats-top](../../nats-tools/nats_top/README.md) that visualizes data from these endpoints on the command line.
 
 > Warning: `nats-server` does not have authentication/authorization for the monitoring endpoint.
 > When you plan to open your `nats-server` to the internet make sure to not expose the monitoring port as well. 

--- a/nats-server/configuration/monitoring.md
+++ b/nats-server/configuration/monitoring.md
@@ -13,11 +13,17 @@ To monitor the NATS messaging system, `nats-server` provides a lightweight HTTP 
 
 All endpoints return a JSON object.
 
-The NATS monitoring endpoints support JSONP and CORS, making it easy to create single page monitoring web applications.
+The NATS monitoring endpoints support [JSONP](https://en.wikipedia.org/wiki/JSONP) and [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing#How_CORS_works), making it easy to create single page monitoring web applications. Part of the NATS eco system is a tool called [nats-top](../../nats-tools/nats_top/README.md) that visualizes data from these endpoints on the command line.
+
+> Warning: `nats-server` does not have authentication/authorization for the monitoring endpoint.
+> When you plan to open your `nats-server` to the internet make sure to not expose the monitoring port as well. 
+> By default monitoring binds to every interface `0.0.0.0` so consider setting monitoring to `localhost` or have appropriate firewall rules.
+>
+> In other words don't do what `http://demo.nats.io:8222/` does! It is done on purpose to simplify the examples below.
 
 ### Enabling monitoring from the command line
 
-To enable the monitoring server, start the NATS server with the monitoring flag `-m` and the monitoring port, or turn it on in the [configuration file](./#configuration-properties).
+To enable the monitoring server, start the NATS server with the monitoring flag `-m` and the monitoring port, or turn it on in the [configuration file](#Enable-monitoring-from-the-configuration-file).
 
 ```text
 -m, --http_port PORT             HTTP PORT for monitoring
@@ -34,7 +40,7 @@ $ nats-server -m 8222
 [4528] 2019/06/01 20:09:58.573090 [INF] nats-server is ready</td>
 ```
 
-To test, run `nats-server -m 8222`, then go to [http://demo.nats.io:8222/](http://demo.nats.io:8222/)
+To test, run `nats-server -m 8222`, then go to [http://localhost:8222/](http://localhost:8222/)
 
 ### Enable monitoring from the configuration file
 
@@ -44,7 +50,13 @@ You can also enable monitoring using the configuration file as follows:
 http_port: 8222
 ```
 
-For example, to monitor this server locally, the endpoint would be [http://demo.nats.io:8222/varz](http://demo.nats.io:8222/varz) reports various general statistics.
+Binding to `localhost` as well:
+
+```yaml
+http: localhost:8222
+```
+
+For example, to monitor this server locally, the endpoint would be [http://localhost:8222/varz](http://localhost:8222/varz). It reports various general statistics.
 
 ## Monitoring endpoints
 


### PR DESCRIPTION
Documenting trace_verbose and warning about exposing monitoring port.
Mention nats-top on monitoring page.
Use localhost in monitoring examples where we start a nats-server.
Mention scope of resolver_preload.

Signed-off-by: Matthias Hanel <mh@synadia.com>