### PR TITLE
Typo correction

### DIFF
--- a/developing-with-nats/connecting/pingpong.md
+++ b/developing-with-nats/connecting/pingpong.md
@@ -4,7 +4,7 @@ The client and server use a simple PING/PONG protocol to check that either of th
 
 ![](../../.gitbook/assets/pingpong.svg)
 
-Once a configurable maximum of outstanding pings without a single pong reply is hit, the connection is closed as stale. Together these two values define a timeout for the connection which specifies how quickly the client will be notified of a problem. This will also help when there is a remote network partition where the operating system does not detect a socket error. Upon connection close the client will attempt to reconnect. When it knows about other server, these will be tried next.
+Once a configurable maximum of outstanding pings without a single pong reply is hit, the connection is closed as stale. Together these two values define a timeout for the connection which specifies how quickly the client will be notified of a problem. This will also help when there is a remote network partition where the operating system does not detect a socket error. Upon connection close the client will attempt to reconnect. When it knows about other servers, these will be tried next.
 
 In the presence of traffic, such as messages or client side pings, the server will not initiate the PING/PONG interaction. 
 


### PR DESCRIPTION
I just corrected a typo: *servers* instead of *server*.