### PR TITLE
Add Rust documentation link

### DIFF
--- a/developing-with-nats/developer.md
+++ b/developing-with-nats/developer.md
@@ -9,6 +9,7 @@ Developing with NATS is a combination of distributed application techniques, com
 | [nats.net](https://github.com/nats-io/nats.net) | [doxygen](http://nats-io.github.io/nats.net/) |
 | [nats.rb](https://github.com/nats-io/nats.rb) | [yard](https://www.rubydoc.info/gems/nats) |
 | [nats.ts](https://github.com/nats-io/nats.ts) | [ts-doc](https://nats-io.github.io/nats.ts) |
+| [nats.rs](https://github.com/nats-io/nats.rs) | [rust doc](https://docs.rs/natsio) |
 
 Not all libraries contain this separate doc, depending on the language community, but be sure to check out the client libraries README for more information.
 


### PR DESCRIPTION
This adds a link in the documentation for the Rust client