### PR TITLE
Add /isFTActive monitoring endpoint

### DIFF
--- a/nats-streaming-concepts/monitoring/endpoints.md
+++ b/nats-streaming-concepts/monitoring/endpoints.md
@@ -346,3 +346,21 @@ When that same durable goes offline, `is_offline` is be set to `true`. Although 
 }
 ```
 
+## /isFTActive
+
+The endpoint [http://localhost:8222/streaming/isFTActive](http://localhost:8222/streaming/isFTActive) indicates, through the HTTP response code, if this server is running as the active server of a fault tolerant (FT) group. If the server is the active server, the HTTP response code returned is 200, otherwise 204 (which indicates either that the server is running as a FT standby server, or simply not running in FT mode).
+
+If the server is FT active:
+```text
+curl -i http://localhost:8222/streaming/isFTActive
+HTTP/1.1 200 OK
+Date: Wed, 24 Jun 2020 14:44:24 GMT
+Content-Length: 0
+```
+
+If not:
+```text
+curl -i http://localhost:8222/streaming/isFTActive
+HTTP/1.1 204 No Content
+Date: Wed, 24 Jun 2020 14:44:37 GMT
+```


### PR DESCRIPTION
Adding the new /isFTActive monitoring endpoint available in NATS Streaming v0.18.0