### PR TITLE
Correct the installation path

### DIFF
--- a/nats-server/installation.md
+++ b/nats-server/installation.md
@@ -79,7 +79,7 @@ Archive:  nats-server.zip
   inflating: nats-server-v2.0.0-linux-amd64/LICENSE
   inflating: nats-server-v2.0.0-linux-amd64/nats-server
 
-> sudo cp nats-server-v2.0.0-linux-amd64/nats-server /usr/bin
+> sudo cp nats-server/nats-server-v2.0.0-linux-amd64/nats-server /usr/bin
 ```
 
 ## Installing From the Source


### PR DESCRIPTION
### Description
This PR correct the installation path before moving the executed file from the unzipped folder

### How to reproduce
```text
> curl -L https://github.com/nats-io/nats-server/releases/download/v2.0.0/nats-server-v2.0.0-linux-amd64.zip -o nats-server.zip

> unzip nats-server.zip -d nats-server
Archive:  nats-server.zip
   creating: nats-server-v2.0.0-linux-amd64/
  inflating: nats-server-v2.0.0-linux-amd64/README.md
  inflating: nats-server-v2.0.0-linux-amd64/LICENSE
  inflating: nats-server-v2.0.0-linux-amd64/nats-server

> sudo cp nats-server/nats-server-v2.0.0-linux-amd64/nats-server /usr/bin
```
The above `sudo cp nats-server-v2.0.0-linux-amd64/nats-server /usr/bin` doesn't work because the source should be ` nats-server/nats-server-v2.0.0-linux-amd64/nats-server`