### PR TITLE
Remove shell prompt character

### DIFF
--- a/nats-tools/mkpasswd.md
+++ b/nats-tools/mkpasswd.md
@@ -9,15 +9,15 @@ A utility for creating `bcrypt` hashes is included with the nats-server distribu
 If you have [go installed](https://golang.org/doc/install), you can easily install the `mkpasswd` tool by doing:
 
 ```text
-> go get github.com/nats-io/nats-server/util/mkpasswd
+go get github.com/nats-io/nats-server/util/mkpasswd
 ```
 
 Alternatively, you can:
 
 ```text
-> git clone git@github.com:nats-io/nats-server
-> cd nats-server/util/mkpasswd
-> go install mkpasswd.go
+git clone git@github.com:nats-io/nats-server
+cd nats-server/util/mkpasswd
+go install mkpasswd.go
 ```
 
 ## Generating bcrypted passwords


### PR DESCRIPTION
Currently, our copy-able snippets have a shell prompt. When someone clicks on
the copy button, the shell prompt gets copied along with the command we want
copied. This removes the shell prompt so that users don't have to edit that out
themselves when they paste one of our commands.

Resolves https://github.com/nats-io/nats.docs/issues/183