### PR TITLE
Fixed apiVersion for eks-efs-provisioner

### DIFF
--- a/nats-on-kubernetes/stan-ft-k8s-aws.md
+++ b/nats-on-kubernetes/stan-ft-k8s-aws.md
@@ -103,7 +103,7 @@ data:
   dns.name: ""
 ---
 kind: Deployment
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: efs-provisioner
 spec:


### PR DESCRIPTION
Updated the ```apiVersion``` for ```efs-provisioner``` **Deployment** config for **NATS EKS** cluster configurations. <br />
Faced this issue while referring to the this [readme.md](https://github.com/nats-io/nats.docs/blob/master/nats-on-kubernetes/stan-ft-k8s-aws.md)

## Error: 

```
no matches for kind “Deployment” in version “extensions/v1beta1”
```

## Resolution: 

Updated the apiVersion from ```extensions/v1beta1``` to ```apps/v1```. And added ```selector``` for the labels.

```
kind: Deployment
apiVersion: apps/v1
metadata:
  name: efs-provisioner
spec:
  replicas: 1
  selector:
    matchLabels:
      app: efs-provisioner
```

## Reasons: 

In Kubernetes 1.16 some apis have been changed.

**Compatibilty**
```
$ kubectl api-resources | grep deployment
deployments                       deploy       apps                           true  
```
