### PR TITLE
Fix typo in nats_api_reference.md

### DIFF
--- a/jetstream/nats_api_reference.md
+++ b/jetstream/nats_api_reference.md
@@ -43,7 +43,7 @@ Non admin APIs - like those for adding a message to the stream will respond with
 
 All the admin actions the `nats` CLI can do falls in the sections below. The API structure are kept in the `api` package in the `jsm.go` repository.
 
-Subjects that and in `T` like `api.JSApiConsumerCreateT` are formats and would need to have the Stream Name and in some cases also the Consumer name interpolated into them. In this case `t := fmt.Sprintf(api.JSApiConsumerCreateT, streamName)` to get the final subject.
+Subjects that end in `T` like `api.JSApiConsumerCreateT` are formats and would need to have the Stream Name and in some cases also the Consumer name interpolated into them. In this case `t := fmt.Sprintf(api.JSApiConsumerCreateT, streamName)` to get the final subject.
 
 The command `nats events` will show you an audit log of all API access events which includes the full content of each admin request, use this to view the structure of messages the `nats` command sends.
 


### PR DESCRIPTION
I believe this should say "end" not "and"