### PR TITLE
fix space and tab

### DIFF
--- a/nats-protocol/nats-protocol/README.md
+++ b/nats-protocol/nats-protocol/README.md
@@ -12,7 +12,7 @@ The NATS server implements a [zero allocation byte parser](https://youtu.be/ylRK
 
 **Control line w/Optional Content**: Each interaction between the client and server consists of a control, or protocol, line of text followed, optionally by message content. Most of the protocol messages don't require content, only `PUB` and `MSG` include payloads.
 
-**Field Delimiters**: The fields of NATS protocol messages are delimited by whitespace characters '```' (space) or``\t\` \(tab\). Multiple whitespace characters will be treated as a single field delimiter.
+**Field Delimiters**: The fields of NATS protocol messages are delimited by whitespace characters '` `'\(space\) or`\t` \(tab\). Multiple whitespace characters will be treated as a single field delimiter.
 
 **Newlines**: NATS uses `CR` followed by `LF` \(`CR+LF`, `\r\n`, `0x0D0A`\) to terminate protocol messages. This newline sequence is also used to mark the end of the message payload in a `PUB` or `MSG` protocol message.
 

--- a/nats-protocol/nats-server-protocol.md
+++ b/nats-protocol/nats-server-protocol.md
@@ -12,7 +12,7 @@ The NATS cluster protocol is very similar to that of the NATS client protocol. I
 
 **Subject names and wildcards**: The NATS cluster protocol has the same features and restrictions as the client with respect to subject names and wildcards. Clients are bound to a single account, however the cluster protocol handles all accounts.
 
-**Field Delimiters**: The fields of NATS protocol messages are delimited by whitespace characters '```' (space) or``\t\` \(tab\). Multiple whitespace characters will be treated as a single field delimiter.
+**Field Delimiters**: The fields of NATS protocol messages are delimited by whitespace characters '` `'\(space\) or`\t` \(tab\). Multiple whitespace characters will be treated as a single field delimiter.
 
 **Newlines**: Like other text-based protocols, NATS uses `CR` followed by `LF` \(`CR+LF`, `\r\n`, `0x0D0A`\) to terminate protocol messages. This newline sequence is also used to mark the beginning of the actual message payload in a `RMSG` protocol message.
 


### PR DESCRIPTION
I modified description `by whitespace characters ' '(space) or\t (tab).`

From
https://docs.nats.io/nats-protocol/nats-protocol#protocol-conventions
https://docs.nats.io/nats-protocol/nats-server-protocol#nats-cluster-protocol-conventions

To
https://github.com/nokute78/nats.docs/tree/space_tab/nats-protocol/nats-protocol#protocol-conventions
https://github.com/nokute78/nats.docs/blob/space_tab/nats-protocol/nats-server-protocol.md#nats-cluster-protocol-conventions


