### PR TITLE
Add operator mode authentication description

### DIFF
--- a/nats-server/configuration/mqtt/mqtt_config.md
+++ b/nats-server/configuration/mqtt/mqtt_config.md
@@ -106,7 +106,7 @@ mqtt {
 
 In operator mode, all users need to provide a JWT in order to connect. For MQTT clients, it means that you need to pass the JWT token as the MQTT password and use any username since MQTT protocol requires a username to be set if a password is set.
 
-In this mode, standard NATS clients are required to sign a `nonce` sent by the server using their private key (see [JWTs and Privacy](../securing_nats/jwt#jwts-and-privacy)). Of course MQTT clients cannot do that, therefore, in order for the JWT to be accepted by the server without the need of signing the `nonce`, the JWT has to have the `Bearer` boolean set to true.
+In this mode, NATS clients are required to sign a `nonce` sent by the server using their private key (see [JWTs and Privacy](../securing_nats/jwt#jwts-and-privacy)). Of course MQTT clients cannot do that, therefore, in order for the JWT to be accepted by the server without the need of signing the `nonce`, the JWT has to have the `Bearer` boolean set to true.
 
 ### Local mode
 

--- a/nats-server/configuration/mqtt/mqtt_config.md
+++ b/nats-server/configuration/mqtt/mqtt_config.md
@@ -100,7 +100,15 @@ mqtt {
 }
 ```
 
-## Authorization of MQTT Users
+## Authentication/Authorization of MQTT Users
+
+### Operator mode
+
+In operator mode, all users need to provide a JWT in order to connect. For MQTT clients, it means that you need to pass the JWT token as the MQTT password and use any username since MQTT protocol requires a username to be set if a password is set.
+
+In this mode, standard NATS clients are required to sign a `nonce` sent by the server using their private key (see [JWTs and Privacy](../securing_nats/jwt#jwts-and-privacy)). Of course MQTT clients cannot do that, therefore, in order for the JWT to be accepted by the server without the need of signing the `nonce`, the JWT has to have the `Bearer` boolean set to true.
+
+### Local mode
 
 A new field when configuring users allows you to restrict which type of connections are allowed for a specific user.
 


### PR DESCRIPTION
In operator mode, MQTT clients need to provide the JWT through the MQTT password.