### PR TITLE
add js arch diagram

### DIFF
--- a/jetstream/concepts/streams.md
+++ b/jetstream/concepts/streams.md
@@ -2,6 +2,8 @@
 
 Streams define how messages are stored and retention duration. Streams consume normal NATS subjects, any message found on those subjects will be delivered to the defined storage system. You can do a normal publish to the subject for unacknowledged delivery, else if you send a Request to the subject the JetStream server will reply with an acknowledgement that it was stored.
 
+![Orders](../../.gitbook/assets/streams-and-consumers-75p.png)
+
 In the diagram above we show the concept of storing all `ORDERS.*` in the Stream even though there are many types of order related messages. We'll show how you can selectively consume subsets of messages later. Relatively speaking the Stream is the most resource consuming component so being able to combine related data in this manner is important to consider.
 
 Streams can consume many subjects. Here we have `ORDERS.*` but we could also consume `SHIPPING.state` into the same Stream should that make sense \(not shown here\).


### PR DESCRIPTION
adding the js arch diagram referenced in 2nd paragraph. docs split causing reference to be invalid