### PR TITLE
docs: latest nats helm chart assigns new label

### DIFF
--- a/nats-on-kubernetes/nats-external-nlb.md
+++ b/nats-on-kubernetes/nats-external-nlb.md
@@ -28,7 +28,7 @@ spec:
     protocol: TCP
     targetPort: 4222
   selector:
-    app: nats
+    app.kubernetes.io/name: nats
 ' | kubectl apply -f -
 
 $ kubectl get svc nats-nlb -o wide


### PR DESCRIPTION
Latest helm chart for nats uses different label, this updates to newer usages of it.
