### PR TITLE
Add JetStream encryption at rest documentation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -141,6 +141,7 @@
   * [GitHub Actions](jetstream/configuration_mgmt/github_actions.md)
   * [Kubernetes Controller](jetstream/configuration_mgmt/kubernetes_controller.md)
 * [Disaster Recovery](jetstream/disaster_recovery.md)
+* [Encryption at Rest](jetstream/encryption_at_rest.md)
 * [Model Deep Dive](jetstream/model_deep_dive.md)
 * [NATS API Reference](jetstream/nats_api_reference.md)
 * [Multi-tenancy & Resource Mgmt](jetstream/resource_management.md)

--- a/jetstream/encryption_at_rest.md
+++ b/jetstream/encryption_at_rest.md
@@ -8,6 +8,7 @@ jetstream : {
     key : “mykey”
     store_dir: datastore
 }
+```
 
 It is recommended to provide the encryption key through an environment variable, such as `JS_KEY` so it will not be persisted in a file.
 
@@ -16,6 +17,7 @@ jetstream : {
     key: $JS_KEY
     store_dir: datastore
 }
+```
 
 You can pass this from the command line this way:
 
@@ -31,7 +33,7 @@ Starting a server with `encrypt` against a datastore that was not encrypted may 
 
 If the data is encrypted with a key and the server is restarted with a different key, the server will fail to decrypt messages when attempting to load them from the store. The server will still be active to support core NATS functionality. If this happens, you’ll see log messages like the following:
 
-``text
+```text
 Error decrypting our stream metafile: chacha20poly1305: message authentication failed
 ```
 

--- a/jetstream/encryption_at_rest.md
+++ b/jetstream/encryption_at_rest.md
@@ -1,0 +1,40 @@
+# Encryption at Rest
+
+The server can be configured to encrypt message blocks when storing them, providing encryption at rest. This can be enabled through configuration. For these examples, assume the file is named `js.conf` and is in the local directory of the NATS server. We normally recommend file system
+encryption rather than JetStream encryption at rest.
+
+```text
+jetstream : {
+    key : “mykey”
+    store_dir: datastore
+}
+
+It is recommended to provide the encryption key through an environment variable, such as `JS_KEY` so it will not be persisted in a file.
+
+```text 
+jetstream : {
+    key: $JS_KEY
+    store_dir: datastore
+}
+
+You can pass this from the command line this way:
+
+```text
+$ env JS_KEY="mykey" nats-server -c js.conf
+```
+
+We currently support two ciphers for encryption: ChaChaPoly20 and [XChaChaPoly1305](https://godoc.org/golang.org/x/crypto/chacha20poly1305). The default selected cipher depends on the platform.
+
+Note that message blocks are encrypted which includes message headers and payloads. Other metadata files are encrypted as well, such as the stream metadata file and consumer metadata files.
+
+Starting a server with `encrypt` against a datastore that was not encrypted may result in failures when it comes to decrypting message blocks, which may not happen immediately upon startup. Instead, it will happen when attempting to deliver messages to consumers. However, when possible, the server will detect if the data was not encrypted and return the data without attempting to decrypt it.
+
+If the data is encrypted with a key and the server is restarted with a different key, the server will fail to decrypt messages when attempting to load them from the store. The server will still be active to support core NATS functionality. If this happens, you’ll see log messages like the following:
+
+``text
+Error decrypting our stream metafile: chacha20poly1305: message authentication failed
+```
+
+Performance considerations: As expected, encryption is likely to decrease performance, but by how much is hard to define. In some performance tests on a MacbookPro 2.8 GHz Intel Core i7 with SSD, we have observed as little as 1% decrease to more than 30%. In addition to CPU cycles required for encryption, the encrypted files may be larger, which results in more data being stored or read.
+
+

--- a/jetstream/encryption_at_rest.md
+++ b/jetstream/encryption_at_rest.md
@@ -29,7 +29,7 @@ We currently support two ciphers for encryption: ChaChaPoly20 and [XChaChaPoly13
 
 Note that message blocks are encrypted which includes message headers and payloads. Other metadata files are encrypted as well, such as the stream metadata file and consumer metadata files.
 
-Starting a server with `encrypt` against a datastore that was not encrypted may result in failures when it comes to decrypting message blocks, which may not happen immediately upon startup. Instead, it will happen when attempting to deliver messages to consumers. However, when possible, the server will detect if the data was not encrypted and return the data without attempting to decrypt it.
+Starting a server with encryption enabled against a datastore that was not encrypted may result in failures when it comes to decrypting message blocks, which may not happen immediately upon startup. Instead, it will happen when attempting to deliver messages to consumers. However, when possible, the server will detect if the data was not encrypted and return the data without attempting to decrypt it.
 
 If the data is encrypted with a key and the server is restarted with a different key, the server will fail to decrypt messages when attempting to load them from the store. The server will still be active to support core NATS functionality. If this happens, you’ll see log messages like the following:
 

--- a/jetstream/encryption_at_rest.md
+++ b/jetstream/encryption_at_rest.md
@@ -1,6 +1,6 @@
 # Encryption at Rest
 
-*Supported since NATS version 2.3*
+*Supported since NATS server version 2.3*
 
 The NATS server can be configured to encrypt message blocks when storing them, providing encryption at rest. This can be enabled through configuration. For these examples, assume the file is named `js.conf` and is in the local directory of the NATS server. We normally recommend file system
 encryption rather than JetStream encryption at rest.

--- a/jetstream/encryption_at_rest.md
+++ b/jetstream/encryption_at_rest.md
@@ -1,6 +1,6 @@
 # Encryption at Rest
 
-The server can be configured to encrypt message blocks when storing them, providing encryption at rest. This can be enabled through configuration. For these examples, assume the file is named `js.conf` and is in the local directory of the NATS server. We normally recommend file system
+The NATS server can be configured to encrypt message blocks when storing them, providing encryption at rest. This can be enabled through configuration. For these examples, assume the file is named `js.conf` and is in the local directory of the NATS server. We normally recommend file system
 encryption rather than JetStream encryption at rest.
 
 ```text

--- a/jetstream/encryption_at_rest.md
+++ b/jetstream/encryption_at_rest.md
@@ -1,5 +1,7 @@
 # Encryption at Rest
 
+*Supported since NATS version 2.3*
+
 The NATS server can be configured to encrypt message blocks when storing them, providing encryption at rest. This can be enabled through configuration. For these examples, assume the file is named `js.conf` and is in the local directory of the NATS server. We normally recommend file system
 encryption rather than JetStream encryption at rest.
 


### PR DESCRIPTION
Initial documentation for JetStream encryption at rest. 

Signed-off-by: Colin Sullivan <colin@synadia.com>