### PR TITLE
Updated Simple Cluster example with cluster_name attr

### DIFF
--- a/nats-server/configuration/clustering/README.md
+++ b/nats-server/configuration/clustering/README.md
@@ -20,14 +20,14 @@ Here is a simple cluster running on the same machine:
 
 ```bash
 # Server A - the 'seed server'
-> nats-server -p 4222 -cluster nats://localhost:4248
+> nats-server -p 4222 -cluster nats://localhost:4248 --cluster_name test-cluster
 
 # Server B
-> nats-server -p 5222 -cluster nats://localhost:5248 -routes nats://localhost:4248
+> nats-server -p 5222 -cluster nats://localhost:5248 -routes nats://localhost:4248 --cluster_name test-cluster
 # Check the output of the server for the selected client and route ports.
 
 # Server C
-> nats-server -p 6222 -cluster nats://localhost:6248 -routes nats://localhost:4248
+> nats-server -p 6222 -cluster nats://localhost:6248 -routes nats://localhost:4248 --cluster_name test-cluster
 # Check the output of the server for the selected client and route ports.
 ```
 
@@ -206,4 +206,3 @@ nats-pub -s "nats://127.0.0.1:4222,nats://127.0.0.1:5222,nats://127.0.0.1:6222" 
 [83330] 2020/02/12 16:22:56.384754 [DBG] 127.0.0.1:63210 - cid:9 - Client connection created
 [83330] 2020/02/12 16:22:56.386467 [DBG] 127.0.0.1:63210 - cid:9 - Client connection closed
 ```
-


### PR DESCRIPTION
When following the example here: https://docs.nats.io/nats-server/configuration/clustering#running-a-simple-cluster

nats-server: v2.3.2

I found that the following error was generated:
```
[1445369] 2021/07/13 21:36:21.872188 [ERR] 127.0.0.1:56620 - rid:3 - Rejecting connection, cluster name "0erg7UY1ojFVRzb6fvkByG" does not match "Br5VvxkEjN1UciMXsr69VT"
```

From what I can tell if a cluster_name was not provided each nat-server instance generates its own cluster_name. On my seed node the above error is shown and on the node being added the following message shows up:
```
[1498779] 2021/07/14 13:59:35.507358 [INF] Cluster name is 886cTyA2RP0qFOu9UtJrWo
...
[1498779] 2021/07/14 13:59:35.509128 [INF] Cluster name updated to F4mCOuAmF1KlIoboRitx8y
[1498779] 2021/07/14 13:59:35.509196 [ERR] 127.0.0.1:4248 - rid:3 - Route Error 'Rejecting connection, cluster name "886cTyA2RP0qFOu9UtJrWo" does not match "F4mCOuAmF1KlIoboRitx8y"'
[1498779] 2021/07/14 13:59:35.509248 [INF] 127.0.0.1:4248 - rid:3 - Router connection closed: Parse Error
[1498779] 2021/07/14 13:59:35.509298 [ERR] 127.0.0.1:4248 - rid:3 - Error flushing: writev tcp 127.0.0.1:51862->127.0.0.1:4248: writev: broken pipe
[1498779] 2021/07/14 13:59:36.520111 [INF] 127.0.0.1:4248 - rid:4 - Route connection created
...
```

It seems to function correctly however from a beginner's perspective the errors are concerning and confusing. Suggesting that the users set a cluster name resolves the error messages and provides a better user experience for beginners.

New commands would be:
```
./nats-server -p 4222 -cluster nats://localhost:4248 --cluster_name test-cluster
```

Seed server startup:
```
[1499857] 2021/07/14 14:06:12.423671 [INF] Starting nats-server
[1499857] 2021/07/14 14:06:12.423779 [INF]   Version:  2.3.2
[1499857] 2021/07/14 14:06:12.423794 [INF]   Git:      [54e16e8]
[1499857] 2021/07/14 14:06:12.423804 [INF]   Name:     NAT5WSXTDMFHXSJ4SIP6K6WJZNRFFLUNSLPK237VVDRB5YEXJARYD2HI
[1499857] 2021/07/14 14:06:12.423816 [INF]   ID:       NAT5WSXTDMFHXSJ4SIP6K6WJZNRFFLUNSLPK237VVDRB5YEXJARYD2HI
[1499857] 2021/07/14 14:06:12.426028 [INF] Listening for client connections on 0.0.0.0:4222
[1499857] 2021/07/14 14:06:12.426694 [INF] Server is ready
[1499857] 2021/07/14 14:06:12.426872 [INF] Cluster name is test-cluster
[1499857] 2021/07/14 14:06:12.427176 [INF] Listening for route connections on localhost:4248
[1499857] 2021/07/14 14:06:27.085922 [INF] 127.0.0.1:52820 - rid:3 - Route connection created
```

Adding a node:
```
[1499902] 2021/07/14 14:06:27.083841 [INF] Starting nats-server
[1499902] 2021/07/14 14:06:27.083898 [INF]   Version:  2.3.2
[1499902] 2021/07/14 14:06:27.083900 [INF]   Git:      [54e16e8]
[1499902] 2021/07/14 14:06:27.083907 [INF]   Name:     NC5OGLVUOFKFTVDOSVJ63WQXPBJC65I2BY46CJSCXXGZV6QJABJVYQAY
[1499902] 2021/07/14 14:06:27.083910 [INF]   ID:       NC5OGLVUOFKFTVDOSVJ63WQXPBJC65I2BY46CJSCXXGZV6QJABJVYQAY
[1499902] 2021/07/14 14:06:27.084526 [INF] Listening for client connections on 0.0.0.0:5222
[1499902] 2021/07/14 14:06:27.084979 [INF] Server is ready
[1499902] 2021/07/14 14:06:27.085022 [INF] Cluster name is test-cluster
[1499902] 2021/07/14 14:06:27.085247 [INF] Listening for route connections on localhost:5248
[1499902] 2021/07/14 14:06:27.086393 [INF] 127.0.0.1:4248 - rid:3 - Route connection created

```