### PR TITLE
docs reference to hashicorp's terraform registry

### DIFF
--- a/jetstream/configuration_mgmt/terraform.md
+++ b/jetstream/configuration_mgmt/terraform.md
@@ -2,21 +2,9 @@
 
 Terraform is a Cloud configuration tool from Hashicorp found at [terraform.io](https://www.terraform.io/), we maintain a Provider for Terraform called [terraform-provider-jetstream](https://github.com/nats-io/terraform-provider-jetstream/) that can maintain JetStream using Terraform.
 
+Find it in the [Terraform registry](https://registry.terraform.io/providers/nats-io/jetstream/latest/docs).
+
 ### Setup
-
-Our provider is not hosted by Hashicorp so installation is a bit more complex than typical. Browse to the [Release Page](https://github.com/nats-io/terraform-provider-jetstream/releases) and download the release for your platform and extract it into your Terraform plugins directory.
-
-```text
-$ unzip -l terraform-provider-jetstream_0.0.2_darwin_amd64.zip
-Archive:  terraform-provider-jetstream_0.0.2_darwin_amd64.zip
-  Length      Date    Time    Name
----------  ---------- -----   ----
-    11357  03-09-2020 10:48   LICENSE
-     1830  03-09-2020 12:53   README.md
- 24574336  03-09-2020 12:54   terraform-provider-jetstream_v0.0.2
-```
-
-Place the `terraform-provider-jetstream_v0.0.2` file in `~/.terraform.d/plugins/terraform-provider-jetstream_v0.0.2`
 
 In your project you can configure the Provider like this:
 
@@ -27,7 +15,7 @@ provider "jetstream" {
 }
 ```
 
-And start using it, here's an example that create the `ORDERS` example. Review the [Project README](https://github.com/nats-io/terraform-provider-jetstream#readme) for full details.
+Example that create the `ORDERS` example. Review the [Project README](https://github.com/nats-io/terraform-provider-jetstream#readme) for full details.
 
 ```text
 resource "jetstream_stream" "ORDERS" {
@@ -66,3 +54,18 @@ output "ORDERS_SUBJECTS" {
 }
 ```
 
+### Manual installation (obsolete)
+
+Browse to the [Release Page](https://github.com/nats-io/terraform-provider-jetstream/releases) and download the release for your platform and extract it into your Terraform plugins directory.
+
+```text
+$ unzip -l terraform-provider-jetstream_0.0.2_darwin_amd64.zip
+Archive:  terraform-provider-jetstream_0.0.2_darwin_amd64.zip
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+    11357  03-09-2020 10:48   LICENSE
+     1830  03-09-2020 12:53   README.md
+ 24574336  03-09-2020 12:54   terraform-provider-jetstream_v0.0.2
+```
+
+Place the `terraform-provider-jetstream_v0.0.2` file in `~/.terraform.d/plugins/terraform-provider-jetstream_v0.0.2`


### PR DESCRIPTION
update the docs, because the provider is now hosted and available on public hashicorp registry