### PR TITLE
Update js example to specify the cred file

### DIFF
--- a/developing-with-nats/security/creds.md
+++ b/developing-with-nats/security/creds.md
@@ -50,11 +50,10 @@ nc.close();
 {% tab title="JavaScript" %}
 ```javascript
 // credentials file contains the JWT and the secret signing key
-let credsFile = path.join(confDir, 'credsfile.creds');
-
-let nc = NATS.connect({
-    url: server.nats,
-    userCreds: credsFile
+const data = fs.readFileSync(creds_file_path);
+  let nc = NATS.connect({
+    servers: [url],
+    authenticator: credsAuthenticator(data)
 });
 ```
 {% endtab %}
@@ -80,11 +79,11 @@ await nc.close()
 {% tab title="TypeScript" %}
 ```typescript
 // credentials file contains the JWT and the secret signing key
-let credsFile = path.join(confDir, 'credsfile.creds');
+const data = fs.readFileSync(creds_file_path);
 
 let nc = await connect({
-    url: server.nats,
-    userCreds: credsFile
+    servers: [url],
+    authenticator: credsAuthenticator(data)
 });
 ```
 {% endtab %}

--- a/developing-with-nats/security/creds.md
+++ b/developing-with-nats/security/creds.md
@@ -79,7 +79,7 @@ await nc.close()
 {% tab title="TypeScript" %}
 ```typescript
 // credentials file contains the JWT and the secret signing key
-const data = fs.readFileSync(creds_file_path);
+const data = fs.readFileSync(credsFile);
 
 let nc = await connect({
     servers: [url],

--- a/developing-with-nats/security/creds.md
+++ b/developing-with-nats/security/creds.md
@@ -50,8 +50,8 @@ nc.close();
 {% tab title="JavaScript" %}
 ```javascript
 // credentials file contains the JWT and the secret signing key
-const data = fs.readFileSync(creds_file_path);
-  let nc = NATS.connect({
+const data = fs.readFileSync(credsFile);
+let nc = NATS.connect({
     servers: [url],
     authenticator: credsAuthenticator(data)
 });

--- a/developing-with-nats/security/creds.md
+++ b/developing-with-nats/security/creds.md
@@ -78,7 +78,8 @@ await nc.close()
 
 {% tab title="TypeScript" %}
 ```typescript
-// credentials file contains the JWT and the secret signing key
+// Credentials file contains the JWT and the secret signing key. This example
+// show how the file could be read using the Node.js runtime.
 const data = fs.readFileSync(credsFile);
 
 let nc = await connect({


### PR DESCRIPTION
## Description
As from example for js client lib:
https://github.com/nats-io/nats.js/blob/master/examples/nats-pub.js
And the connect ops definition:
https://github.com/nats-io/nats.js/blob/9d53eda057472aceb5b5af9451f2cb7a0d5d033b/index.d.ts#L54

The example here is out of date and not correct. Need update