### PR TITLE
Update configuration docs to use more precise units

### DIFF
--- a/nats-server/configuration/README.md
+++ b/nats-server/configuration/README.md
@@ -134,10 +134,10 @@ authorization: {
 
 | Property | Description | Default |
 | :--- | :--- | :--- |
-| `max_connections` | Maximum number of active client connections. | `64K` |
-| `max_control_line` | Maximum length of a protocol line \(including combined length of subject and queue group\). Increasing this value may require [client changes](../../developing-with-nats/connecting/misc.md#set-the-maximum-control-line-size) to be used. Applies to all traffic. | `4Kb` |
-| `max_payload` | Maximum number of bytes in a message payload. Reducing this size may force you to implement [chunking](../../developing-with-nats/connecting/misc.md#get-the-maximum-payload-size) in your clients. Applies to client and leafnode payloads. It is not recommended to use values over 8Mb but `max_payload` can be set up to 64Mb. | `1Mb` |
-| `max_pending` | Maximum number of bytes buffered for a connection Applies to client connections. | `64Mb` |
+| `max_connections` | Maximum number of active client connections. | `65536` |
+| `max_control_line` | Maximum length of a protocol line \(including combined length of subject and queue group\). Increasing this value may require [client changes](../../developing-with-nats/connecting/misc.md#set-the-maximum-control-line-size) to be used. Applies to all traffic. | `4KiB` |
+| `max_payload` | Maximum number of bytes in a message payload. Reducing this size may force you to implement [chunking](../../developing-with-nats/connecting/misc.md#get-the-maximum-payload-size) in your clients. Applies to client and leafnode payloads. It is not recommended to use values over 8MiB but `max_payload` can be set up to 64MiB. | `1MiB` |
+| `max_pending` | Maximum number of bytes buffered for a connection Applies to client connections. | `64MiB` |
 | `max_subscriptions` | Maximum numbers of subscriptions per client and leafnode accounts connection. | `0`, unlimited |
 
 ### Authentication and Authorization


### PR DESCRIPTION
In reviewing the configuration docs, I was confused about what values were actually intended. I had go to look at the source code [over here](https://github.com/nats-io/nats-server/blob/b3c19b9dd19171b58da5b5135491848cf72da599/server/const.go#L74) to understand better, so I opened this PR in the hopes that future readers will not feel the need to go source diving, and just to open the conversation around consistent units in the docs.

`Mb` is "megabits", not "megabytes", and just plain `MB` for megabytes would imply base-10... but the values in `const.go` are base-2, so `MiB` is the best unit to use there.

`64K` is ambiguous, and I guessed wrongly that it would be 64000... when that is also base-2 as 65536.