### PR TITLE
Update docker NATS cluster instructions

### DIFF
--- a/nats-server/nats_docker/README.md
+++ b/nats-server/nats_docker/README.md
@@ -36,21 +36,24 @@ $ docker network create nats
 ```
 
 ```bash
-docker run --name nats --network nats --rm -p 4222:4222 -p 8222:8222 nats
-[INF] Starting nats-server version 2.1.0
-[INF] Git commit [1cc5ae0]
-[INF] Starting http monitor on 0.0.0.0:8222
-[INF] Listening for client connections on 0.0.0.0:4222
-[INF] Server id is NDHWPPFNP2ASLPHXTMUU63NKUTZIKPJPMVBAHBAWJVAOSJG4QPXVRWL3
-[INF] Server is ready
-[INF] Listening for route connections on 0.0.0.0:6222
+docker run --name nats --network nats --rm -p 4222:4222 -p 8222:8222 nats --http_port 8222 --cluster_name NATS --cluster nats://0.0.0.0:6222
+[1] 2021/09/28 09:21:56.554756 [INF] Starting nats-server
+[1] 2021/09/28 09:21:56.554864 [INF]   Version:  2.6.1
+[1] 2021/09/28 09:21:56.554878 [INF]   Git:      [c91f0fe]
+[1] 2021/09/28 09:21:56.554894 [INF]   Name:     NDIQLLD2UGGPSAEYBKHW3S2JB2DXIAFHMIWWRUBAX7FC4RTQX4ET2JNQ
+[1] 2021/09/28 09:21:56.555001 [INF]   ID:       NDIQLLD2UGGPSAEYBKHW3S2JB2DXIAFHMIWWRUBAX7FC4RTQX4ET2JNQ
+[1] 2021/09/28 09:21:56.557658 [INF] Starting http monitor on 0.0.0.0:8222
+[1] 2021/09/28 09:21:56.557967 [INF] Listening for client connections on 0.0.0.0:4222
+[1] 2021/09/28 09:21:56.559224 [INF] Server is ready
+[1] 2021/09/28 09:21:56.559375 [INF] Cluster name is NATS
+[1] 2021/09/28 09:21:56.559433 [INF] Listening for route connections on 0.0.0.0:6222
 ```
 
 Next, start another couple of servers and point them to the seed server to make them form a cluster:
 
 ```bash
-docker run --name nats-1 --network nats --rm nats --cluster nats://0.0.0.0:6222 --routes=nats://ruser:T0pS3cr3t@nats:6222
-docker run --name nats-2 --network nats --rm nats --cluster nats://0.0.0.0:6222 --routes=nats://ruser:T0pS3cr3t@nats:6222
+docker run --name nats-1 --network nats --rm nats --cluster_name NATS --cluster nats://0.0.0.0:6222 --routes=nats://ruser:T0pS3cr3t@nats:6222
+docker run --name nats-2 --network nats --rm nats --cluster_name NATS --cluster nats://0.0.0.0:6222 --routes=nats://ruser:T0pS3cr3t@nats:6222
 ```
 
 **NOTE** Since the Docker image protects routes using credentials we need to provide them above. Extracted [from Docker image configuration](https://github.com/nats-io/nats-docker/blob/6fb8c05311bb4d1554390f66abb0a5ebef1e1c9d/2.1.0/scratch/amd64/nats-server.conf#L13-L19)
@@ -60,39 +63,39 @@ To verify the routes are connected, you can make a request to the monitoring end
 ```bash
 curl http://127.0.0.1:8222/routez
 {
-  "server_id": "ND34PZ64QLLJKSU5SLSWRS5EUXEKNHW5BUVLCNFWA56R4D7XKDYWJFP7",
-  "now": "2019-10-17T21:29:38.126871819Z",
+  "server_id": "NDIQLLD2UGGPSAEYBKHW3S2JB2DXIAFHMIWWRUBAX7FC4RTQX4ET2JNQ",
+  "now": "2021-09-28T09:22:15.8019785Z",
   "num_routes": 2,
   "routes": [
     {
-      "rid": 7,
-      "remote_id": "NDF4PMDKSKIZBYHUU5R7NA5KXNXLTKHVLN6ALBLQPAWTJKRAWJVPN4HA",
+      "rid": 5,
+      "remote_id": "NBRAUY3YSVFYU7BFWI2YF5VPQFGO2XCKKAHYZ7ETCMGB3SQY3FDFTYOQ",
       "did_solicit": false,
       "is_configured": false,
-      "ip": "172.17.0.3",
-      "port": 59810,
+      "ip": "172.18.0.3",
+      "port": 59092,
       "pending_size": 0,
-      "rtt": "561µs",
-      "in_msgs": 0,
-      "out_msgs": 0,
-      "in_bytes": 0,
-      "out_bytes": 0,
-      "subscriptions": 0
+      "rtt": "1.2505ms",
+      "in_msgs": 4,
+      "out_msgs": 3,
+      "in_bytes": 2714,
+      "out_bytes": 1943,
+      "subscriptions": 35
     },
     {
-      "rid": 8,
-      "remote_id": "ND6P52R5PASBYXK2MK44P6BYV7Q7PZEMTZJ5O5K7WXF4F54UD3EKVBSC",
+      "rid": 6,
+      "remote_id": "NA5STTST5GYFCD22M2I3VDJ57LQKOU35ZVWKQY3O5QRFGOPC3RFDIDVJ",
       "did_solicit": false,
       "is_configured": false,
-      "ip": "172.17.0.4",
-      "port": 37882,
+      "ip": "172.18.0.4",
+      "port": 47424,
       "pending_size": 0,
-      "rtt": "772µs",
-      "in_msgs": 0,
-      "out_msgs": 0,
-      "in_bytes": 0,
-      "out_bytes": 0,
-      "subscriptions": 0
+      "rtt": "1.2008ms",
+      "in_msgs": 4,
+      "out_msgs": 1,
+      "in_bytes": 2930,
+      "out_bytes": 833,
+      "subscriptions": 35
     }
   ]
 }
@@ -109,15 +112,16 @@ services:
     image: nats
     ports:
       - "8222:8222"
+    command: "--cluster_name NATS --cluster nats://0.0.0.0:6222 --http_port 8222 "
     networks: ["nats"]
   nats-1:
     image: nats
-    command: "--cluster nats://0.0.0.0:6222 --routes=nats://ruser:T0pS3cr3t@nats:6222"
+    command: "--cluster_name NATS --cluster nats://0.0.0.0:6222 --routes=nats://ruser:T0pS3cr3t@nats:6222"
     networks: ["nats"]
     depends_on: ["nats"]
   nats-2:
     image: nats
-    command: "--cluster nats://0.0.0.0:6222 --routes=nats://ruser:T0pS3cr3t@nats:6222"
+    command: "--cluster_name NATS --cluster nats://0.0.0.0:6222 --routes=nats://ruser:T0pS3cr3t@nats:6222"
     networks: ["nats"]
     depends_on: ["nats"]
 
@@ -129,21 +133,46 @@ networks:
 Now we use Docker Compose to create the cluster that will be using the `nats` network:
 
 ```bash
-$ docker-compose -f nats-cluster.yaml up
-Recreating docs_nats_1   ... done
-Recreating docs_nats-2_1 ... done
-Recreating docs_nats-1_1 ... done
-Attaching to docs_nats-2_1, docs_nats_1, docs_nats-1_1
-nats-2_1  | [1] 2019/10/19 06:41:26.064501 [INF] Starting nats-server version 2.1.0
-nats-2_1  | [1] 2019/10/19 06:41:26.064783 [INF] Git commit [1cc5ae0]
-nats_1    | [1] 2019/10/19 06:41:26.359150 [INF] Starting nats-server version 2.1.0
-nats_1    | [1] 2019/10/19 06:41:26.359365 [INF] Git commit [1cc5ae0]
-nats_1    | [1] 2019/10/19 06:41:26.360540 [INF] Starting http monitor on 0.0.0.0:8222
-nats-1_1  | [1] 2019/10/19 06:41:26.578773 [INF] 172.18.0.2:6222 - rid:1 - Route connection created
-nats_1    | [1] 2019/10/19 06:41:27.138198 [INF] 172.18.0.4:38900 - rid:2 - Route connection created
-nats-2_1  | [1] 2019/10/19 06:41:27.147816 [INF] 172.18.0.2:6222 - rid:1 - Route connection created
-nats-2_1  | [1] 2019/10/19 06:41:27.150367 [INF] 172.18.0.3:60702 - rid:2 - Route connection created
-nats-1_1  | [1] 2019/10/19 06:41:27.153078 [INF] 172.18.0.4:6222 - rid:3 - Route connection created
+$ docker compose -f nats-cluster.yaml up
+[+] Running 3/3
+ ⠿ Container xxx_nats_1    Created
+ ⠿ Container xxx_nats-1_1  Created
+ ⠿ Container xxx_nats-2_1  Created
+Attaching to nats-1_1, nats-2_1, nats_1
+nats_1    | [1] 2021/09/28 10:42:36.742844 [INF] Starting nats-server
+nats_1    | [1] 2021/09/28 10:42:36.742898 [INF]   Version:  2.6.1
+nats_1    | [1] 2021/09/28 10:42:36.742913 [INF]   Git:      [c91f0fe]
+nats_1    | [1] 2021/09/28 10:42:36.742929 [INF]   Name:     NCZIIQ6QT4KT5K5WBP7H2RRBM4MSYD4C2TVSRZOZN57EHX6VTF4EWXAU
+nats_1    | [1] 2021/09/28 10:42:36.742954 [INF]   ID:       NCZIIQ6QT4KT5K5WBP7H2RRBM4MSYD4C2TVSRZOZN57EHX6VTF4EWXAU
+nats_1    | [1] 2021/09/28 10:42:36.745289 [INF] Starting http monitor on 0.0.0.0:8222
+nats_1    | [1] 2021/09/28 10:42:36.745737 [INF] Listening for client connections on 0.0.0.0:4222
+nats_1    | [1] 2021/09/28 10:42:36.750381 [INF] Server is ready
+nats_1    | [1] 2021/09/28 10:42:36.750669 [INF] Cluster name is NATS
+nats_1    | [1] 2021/09/28 10:42:36.751444 [INF] Listening for route connections on 0.0.0.0:6222
+nats-1_1  | [1] 2021/09/28 10:42:37.709888 [INF] Starting nats-server
+nats-1_1  | [1] 2021/09/28 10:42:37.709977 [INF]   Version:  2.6.1
+nats-1_1  | [1] 2021/09/28 10:42:37.709999 [INF]   Git:      [c91f0fe]
+nats-1_1  | [1] 2021/09/28 10:42:37.710023 [INF]   Name:     NBHTXXY3HYZVPXITYQ73BSDA5CQZINTKYRM23XFI46RWWTTUP5TAXQMB
+nats-1_1  | [1] 2021/09/28 10:42:37.710042 [INF]   ID:       NBHTXXY3HYZVPXITYQ73BSDA5CQZINTKYRM23XFI46RWWTTUP5TAXQMB
+nats-1_1  | [1] 2021/09/28 10:42:37.711646 [INF] Listening for client connections on 0.0.0.0:4222
+nats-1_1  | [1] 2021/09/28 10:42:37.712197 [INF] Server is ready
+nats-1_1  | [1] 2021/09/28 10:42:37.712376 [INF] Cluster name is NATS
+nats-1_1  | [1] 2021/09/28 10:42:37.712469 [INF] Listening for route connections on 0.0.0.0:6222
+nats_1    | [1] 2021/09/28 10:42:37.718918 [INF] 172.18.0.4:52950 - rid:4 - Route connection created
+nats-1_1  | [1] 2021/09/28 10:42:37.719906 [INF] 172.18.0.3:6222 - rid:4 - Route connection created
+nats-2_1  | [1] 2021/09/28 10:42:37.731357 [INF] Starting nats-server
+nats-2_1  | [1] 2021/09/28 10:42:37.731518 [INF]   Version:  2.6.1
+nats-2_1  | [1] 2021/09/28 10:42:37.731531 [INF]   Git:      [c91f0fe]
+nats-2_1  | [1] 2021/09/28 10:42:37.731543 [INF]   Name:     NCG6UQ2N3IHE6OS76TL46RNZBAPHNUCQSA64FDFHG5US2LLJOQLD5ZK2
+nats-2_1  | [1] 2021/09/28 10:42:37.731554 [INF]   ID:       NCG6UQ2N3IHE6OS76TL46RNZBAPHNUCQSA64FDFHG5US2LLJOQLD5ZK2
+nats-2_1  | [1] 2021/09/28 10:42:37.732893 [INF] Listening for client connections on 0.0.0.0:4222
+nats-2_1  | [1] 2021/09/28 10:42:37.733431 [INF] Server is ready
+nats-2_1  | [1] 2021/09/28 10:42:37.733491 [INF] Cluster name is NATS
+nats-2_1  | [1] 2021/09/28 10:42:37.733835 [INF] Listening for route connections on 0.0.0.0:6222
+nats_1    | [1] 2021/09/28 10:42:37.740860 [INF] 172.18.0.5:54616 - rid:5 - Route connection created
+nats-2_1  | [1] 2021/09/28 10:42:37.741557 [INF] 172.18.0.3:6222 - rid:4 - Route connection created
+nats-1_1  | [1] 2021/09/28 10:42:37.743981 [INF] 172.18.0.5:6222 - rid:5 - Route connection created
+nats-2_1  | [1] 2021/09/28 10:42:37.744332 [INF] 172.18.0.4:40250 - rid:5 - Route connection created
 ```
 
 ### Testing the Clusters
@@ -152,28 +181,29 @@ Now, the following should work: make a subscription on one of the nodes and publ
 
 ```bash
 $ docker run --network nats --rm -it synadia/nats-box
-~ # nats-sub -s nats://nats:4222 hello &
-Listening on [hello]
+~ # nats sub -s nats://nats:4222 hello &
+16e55f1c4f3c:~# 10:44:58 Subscribing on hello
 
-~ # nats-pub -s "nats://nats-1:4222" hello first
-~ # nats-pub -s "nats://nats-2:4222" hello second
+~ # nats pub -s "nats://nats-1:4222" hello first
+~ # nats pub -s "nats://nats-2:4222" hello second
 ```
 
 Also stopping the seed node to which the subscription was done, should trigger an automatic failover to the other nodes:
 
 ```bash
-$ docker stop nats
+$ docker compose -f nats-cluster.yaml stop nats
 
 ... 
-Disconnected: will attempt reconnects for 10m
-Reconnected [nats://172.17.0.4:4222]
+16e55f1c4f3c:~# 10:47:28 Disconnected due to: EOF, will attempt reconnect
+10:47:28 Disconnected due to: EOF, will attempt reconnect
+10:47:28 Reconnected [nats://172.18.0.4:4222]
 ```
 
 Publishing again will continue to work after the reconnection:
 
 ```bash
-~ # nats-pub -s "nats://nats-1:4222" hello again
-~ # nats-pub -s "nats://nats-2:4222" hello again
+~ # nats pub -s "nats://nats-1:4222" hello again
+~ # nats pub -s "nats://nats-2:4222" hello again
 ```
 
 ## Tutorial


### PR DESCRIPTION
I'm new to NATS, but this guide didn't work for me, and seems outdated:
* the server needs cluster options to be specified in order to work in cluster mode.
* the name for the cluster needs to be specified to avoid error messages on start-up.
* the port for the monitoring server needs to be specified else it is not started by the server.
* `docker-compose` is now `docker compose`
* `synadia/nats-box` has been updated, and `nats-pub` and `nats-sub` are replaced with the `nats` command.

The above works for me, but please test!