### PR TITLE
Add python doc link

### DIFF
--- a/using-nats/developing-with-nats/developer.md
+++ b/using-nats/developing-with-nats/developer.md
@@ -8,7 +8,7 @@ Developing with NATS is a combination of distributed application techniques, com
 | Java | [nats.java](https://github.com/nats-io/nats.java), [javadoc](https://javadoc.io/doc/io.nats/jnats) |
 | C# | [nats.net](https://github.com/nats-io/nats.net), [doxygen](http://nats-io.github.io/nats.net/), [package](https://www.nuget.org/packages/NATS.Client/0.14.1) |
 | JavaScript | [Node.js](https://github.com/nats-io/nats.js#readme), [deno](https://github.com/nats-io/nats.deno/blob/main/README.md), [WebSocket](https://github.com/nats-io/nats.ws#readme) |
-| Python | [nats.py](https://github.com/nats-io/nats.py) |
+| Python | [nats.py](https://github.com/nats-io/nats.py) | [doc](https://nats-io.github.io/nats.py/) |
 | Ruby | [nats-pure.rb](https://github.com/nats-io/nats-pure.rb), [yard](https://www.rubydoc.info/gems/nats) |
 | C | [nats.c](https://github.com/nats-io/nats.c), [doc](http://nats-io.github.io/nats.c) |
 | Rust | [nats.rs](https://github.com/nats-io/nats.rs), [rust doc](https://docs.rs/nats) |

--- a/using-nats/developing-with-nats/developer.md
+++ b/using-nats/developing-with-nats/developer.md
@@ -8,7 +8,7 @@ Developing with NATS is a combination of distributed application techniques, com
 | Java | [nats.java](https://github.com/nats-io/nats.java), [javadoc](https://javadoc.io/doc/io.nats/jnats) |
 | C# | [nats.net](https://github.com/nats-io/nats.net), [doxygen](http://nats-io.github.io/nats.net/), [package](https://www.nuget.org/packages/NATS.Client/0.14.1) |
 | JavaScript | [Node.js](https://github.com/nats-io/nats.js#readme), [deno](https://github.com/nats-io/nats.deno/blob/main/README.md), [WebSocket](https://github.com/nats-io/nats.ws#readme) |
-| Python | [nats.py](https://github.com/nats-io/nats.py) | [doc](https://nats-io.github.io/nats.py/) |
+| Python | [nats.py](https://github.com/nats-io/nats.py), [doc](https://nats-io.github.io/nats.py/) |
 | Ruby | [nats-pure.rb](https://github.com/nats-io/nats-pure.rb), [yard](https://www.rubydoc.info/gems/nats) |
 | C | [nats.c](https://github.com/nats-io/nats.c), [doc](http://nats-io.github.io/nats.c) |
 | Rust | [nats.rs](https://github.com/nats-io/nats.rs), [rust doc](https://docs.rs/nats) |


### PR DESCRIPTION
Adds a link to the python client library documentation to the main developer's guide page