### PR TITLE
Fix broken links in "Securing NATS" documentation

### DIFF
--- a/running-a-nats-service/configuration/securing_nats/README.md
+++ b/running-a-nats-service/configuration/securing_nats/README.md
@@ -2,6 +2,6 @@
 
 The NATS server provides several forms of security:
 
-* Connections can be [_encrypted_ with TLS](/running-a-nats-service/configurationnfiguration/securing_nats/tls.md)
-* Client connections can require [_authentication_](/running-a-nats-service/configurationnfiguration/securing_nats/auth_intro)
+* Connections can be [_encrypted_ with TLS](/running-a-nats-service/configuration/securing_nats/tls.md)
+* Client connections can require [_authentication_](/running-a-nats-service/configuration/securing_nats/auth_intro)
 * Clients can require [_authorization_](authorization.md) for subjects they publish or subscribe to


### PR DESCRIPTION
Fixed a typo (`configurationnfiguration` into `configuration`).