### PR TITLE
Clarify JS constants references and fix constant name

### DIFF
--- a/using-nats/jetstream/nats_api_reference.md
+++ b/using-nats/jetstream/nats_api_reference.md
@@ -4,7 +4,7 @@ The normal way to use JetStream is through the NATS client libraries which expos
 
 ## Reference
 
-All of these subjects are found as constants in the NATS Server source, so for example the `$JS.API.STREAM.LIST` is a constant in the nats-server source `api.JetStreamListStreams` tables below will reference these constants and likewise data structures in the server for payloads.
+All of these subjects are found as constants in the NATS Server source, so for example the subject `$JS.API.STREAM.LIST` is represented by `api.JSApiStreamList` constant in the nats-server source. Tables below will reference these constants and payload related data structures.
 
 ## Error Handling
 


### PR DESCRIPTION
Constant 'api.JetStreamListStreams' doesn't exist, that is  typo probably. Also, rephrased it a bit, to make it understandable. 