### PR TITLE
Update mem_resolver.md

### DIFF
--- a/running-a-nats-service/configuration/securing_nats/jwt/mem_resolver.md
+++ b/running-a-nats-service/configuration/securing_nats/jwt/mem_resolver.md
@@ -142,5 +142,5 @@ You can then [test it](mem_resolver.md#testing-the-configuration).
 To test the configuration, simply use one of the standard tools:
 
 ```shell
-nats pub -creds ~/.nkeys/creds/memory/accounts/A/TA.creds hello world
+nats pub --creds ~/.nkeys/creds/memory/A/TA.creds hello world
 ```


### PR DESCRIPTION
❯ tree .nkeys
.nkeys
├── creds
│   └── memory
│       └── A
│           └── TA.creds
└── keys
    ├── A
    │   └── AM
    │       └── AAMQZJVE6CBA5THIRHYOZLAL7CYXCEIDXY4CP3GTCATYDIV5FD46RMDV.nk
    ├── O
    │   └── BI
    │       └── OBI24HD7CSLVC2JJLCBQNASOJD3EW2P3XL52WV6BA3CISUV5B5TPC7DO.nk
    └── U
        └── D3
            └── UD35IAAVVDZPATAVVBM7ZLQCDZ26KJAA4P5XPXF7FY66QFBBGCJQDGBV.nk


was missing a dash at -creds and also the path of the resulting cred has an extra /accounts..?