### PR TITLE
Removed note referring to JetStream pre-cluster support

### DIFF
--- a/using-nats/jetstream/model_deep_dive.md
+++ b/using-nats/jetstream/model_deep_dive.md
@@ -481,8 +481,6 @@ Output
 
 JetStream file storage is very efficient, storing as little extra information about the message as possible.
 
-**NOTE:** This might change once clustering is supported.
-
 We do store some message data with each message, namely:
 
 * Message headers


### PR DESCRIPTION
There was an obsolete note under Storage Overhead section that references _JetStream pre-cluster support_.  Removed.