### PR TITLE
Fixing links in client.md

### DIFF
--- a/running-a-nats-service/clients.md
+++ b/running-a-nats-service/clients.md
@@ -2,9 +2,9 @@
 
 A NATS client is an application making a connection to one of the nats servers pointed to by its connection URL, and uses a credential file to authenticate and indicate its authorization to the server and the whole NATS infrastructure.
 
-The nats-server doesn't come bundled with any clients, but its companion is the [`nats`](/using-nats/nats-tools/nats%20CLI/readme.md) CLI tool that you should install (even if you don't intend to run your own servers) as it is the best tool to use to test, monitor, manage and generally interact with a NATS infrastructure (regardless of that infrastructure being an isolated local server, a leaf node server, a cluster or even a global super-cluster).
+The nats-server doesn't come bundled with any clients, but its companion is the [`nats`](/using-nats/nats-tools/nats_cli) CLI tool that you should install (even if you don't intend to run your own servers) as it is the best tool to use to test, monitor, manage and generally interact with a NATS infrastructure (regardless of that infrastructure being an isolated local server, a leaf node server, a cluster or even a global super-cluster).
 
-Other NATS client tools to know about are the [`nsc`](/using-nats/nats-tools/nsc) CLI tool (to manage accounts attributes and user JWT tokens) and the ['nk'](/using-nats/nats-tools/nk.md) tool (and library) to manage Nkeys.
+Other NATS client tools to know about are the [`nsc`](/using-nats/nats-tools/nsc) CLI tool (to manage accounts attributes and user JWT tokens) and the ['nk'](/using-nats/nats-tools/nk) tool (and library) to manage Nkeys.
 
 Also, most client libraries come with sample programs that allow you to publish, subscribe, send requests and reply messages.
 
@@ -27,7 +27,7 @@ Binaries are also available as [GitHub Releases](https://github.com/nats-io/nats
 
 ## Testing your setup
 
-Open a terminal and [start a nats-server](/running-a-nats-service/running/README.md):
+Open a terminal and [start a nats-server](/running-a-nats-service/introduction/running):
 
 ```shell
 nats-server
@@ -84,7 +84,7 @@ Example output
 
 If you had created a subscriber, you should notice output on the subscriber telling you that it disconnected, and reconnected. The server output above is more interesting. You can see the subscriber send a `CONNECT` protocol message and a `PING` which was responded to by the server with a `PONG`.
 
-> You can learn more about the [NATS protocol here](/reference/nats-protocol/nats-protocol/README.md), but more interesting than the protocol description is [an interactive demo](../reference/nats-protocol/nats-protocol-demo.md).
+> You can learn more about the [NATS protocol here](/reference/reference-protocols/nats-protocol), but more interesting than the protocol description is [an interactive demo](/reference/reference-protocols/nats-protocol-demo).
 
 On a third terminal, publish your first message:
 


### PR DESCRIPTION
A bunch of links in the `/running-a-nats-service/clients` page were broken on https://docs.nats.io/running-a-nats-service/clients. I've fixed them in this PR.