### PR TITLE
Update listen address to 0.0.0.0

### DIFF
--- a/running-a-nats-service/configuration/clustering/jetstream_clustering/README.md
+++ b/running-a-nats-service/configuration/clustering/jetstream_clustering/README.md
@@ -59,7 +59,7 @@ jetstream {
 
 cluster {
   name: C1
-  listen: localhost:6222
+  listen: 0.0.0.0:6222
   routes: [
     nats-route://host_b:6222
     nats-route://host_c:6222
@@ -79,7 +79,7 @@ jetstream {
 
 cluster {
   name: C1
-  listen: localhost:6222
+  listen: 0.0.0.0:6222
   routes: [
     nats-route://host_a:6222
     nats-route://host_c:6222
@@ -99,7 +99,7 @@ jetstream {
 
 cluster {
   name: C1
-  listen: localhost:6222
+  listen: 0.0.0.0:6222
   routes: [
     nats-route://host_a:6222
     nats-route://host_b:6222


### PR DESCRIPTION
On Ubuntu 20.04, the suggested configuration did not work because publishing to `localhost` does not allow external services to reach NATS.  Replaced with `0.0.0.0`.