### PR TITLE
$JS.API.CONSUMER.DURABLE.CREATE corrected to two token arguments.

### DIFF
--- a/using-nats/jetstream/nats_api_reference.md
+++ b/using-nats/jetstream/nats_api_reference.md
@@ -77,14 +77,14 @@ The API uses JSON for inputs and outputs, all the responses are typed using a `t
 
 ### Consumers
 
-| Subject | Constant | Description | Request Payload | Response Payload |
-| :--- | :--- | :--- | :--- | :--- |
-| `$JS.API.CONSUMER.CREATE.*` | `api.JSApiConsumerCreateT` | Create an ephemeral Consumer | `api.ConsumerConfig`, Stream name in subject | `api.JSApiConsumerCreateResponse` |
-| `$JS.API.CONSUMER.DURABLE.CREATE.*` | `api.JSApiDurableCreateT` | Create an Consumer | `api.ConsumerConfig`, Stream name in subject | `api.JSApiConsumerCreateResponse` |
-| `$JS.API.CONSUMER.LIST.*` | `api.JSApiConsumerListT` | Paged list of known Consumers including their current info | `api.JSApiConsumerListRequest` | `api.JSApiConsumerListResponse` |
-| `$JS.API.CONSUMER.NAMES.*` | `api.JSApiConsumerNamesT` | Paged list of known Consumer names | `api.JSApiConsumerNamesRequest` | `api.JSApiConsumerNamesResponse` |
-| `$JS.API.CONSUMER.INFO.*.*` | `api.JSApiConsumerInfoT` | Information about an Consumer | empty payload, Stream and Consumer names in subject | `api.JSApiConsumerInfoResponse` |
-| `$JS.API.CONSUMER.DELETE.*.*` | `api.JSApiConsumerDeleteT` | Deletes an Consumer | empty payload, Stream and Consumer names in subject | `api.JSApiConsumerDeleteResponse` |
+| Subject                               | Constant | Description | Request Payload | Response Payload |
+|:--------------------------------------| :--- | :--- | :--- | :--- |
+| `$JS.API.CONSUMER.CREATE.*`           | `api.JSApiConsumerCreateT` | Create an ephemeral Consumer | `api.ConsumerConfig`, Stream name in subject | `api.JSApiConsumerCreateResponse` |
+| `$JS.API.CONSUMER.DURABLE.CREATE.*.*` | `api.JSApiDurableCreateT` | Create an Consumer | `api.ConsumerConfig`, Stream name in subject | `api.JSApiConsumerCreateResponse` |
+| `$JS.API.CONSUMER.LIST.*`             | `api.JSApiConsumerListT` | Paged list of known Consumers including their current info | `api.JSApiConsumerListRequest` | `api.JSApiConsumerListResponse` |
+| `$JS.API.CONSUMER.NAMES.*`            | `api.JSApiConsumerNamesT` | Paged list of known Consumer names | `api.JSApiConsumerNamesRequest` | `api.JSApiConsumerNamesResponse` |
+| `$JS.API.CONSUMER.INFO.*.*`           | `api.JSApiConsumerInfoT` | Information about an Consumer | empty payload, Stream and Consumer names in subject | `api.JSApiConsumerInfoResponse` |
+| `$JS.API.CONSUMER.DELETE.*.*`         | `api.JSApiConsumerDeleteT` | Deletes an Consumer | empty payload, Stream and Consumer names in subject | `api.JSApiConsumerDeleteResponse` |
 
 ### ACLs
 


### PR DESCRIPTION
As reported in Slack community, line 83 should reflect `$JS.API.CONSUMER.DURABLE.CREATE.*.*` indicating two token parameters.