### PR TITLE
Fix broken link to nats CLI readme in tokens.md

### DIFF
--- a/running-a-nats-service/configuration/securing_nats/auth_intro/tokens.md
+++ b/running-a-nats-service/configuration/securing_nats/auth_intro/tokens.md
@@ -28,7 +28,7 @@ nats sub -s nats://s3cr3t@localhost:4222 ">"
 
 Tokens can be bcrypted enabling an additional layer of security, as the clear-text version of the token would not be persisted on the server configuration file.
 
-You can generate bcrypted tokens and passwords using the [`nats`](../../../../using-nats/nats-tools/nats_cli/readme.md) tool:
+You can generate bcrypted tokens and passwords using the [`nats`](../../../../using-nats/nats-tools/nats_cli/) tool:
 
 ```shell
 nats server passwd

--- a/running-a-nats-service/configuration/securing_nats/auth_intro/tokens.md
+++ b/running-a-nats-service/configuration/securing_nats/auth_intro/tokens.md
@@ -28,7 +28,7 @@ nats sub -s nats://s3cr3t@localhost:4222 ">"
 
 Tokens can be bcrypted enabling an additional layer of security, as the clear-text version of the token would not be persisted on the server configuration file.
 
-You can generate bcrypted tokens and passwords using the [`nats`](../../../../using-nats/nats-tools/nats%20CLI/readme.md) tool:
+You can generate bcrypted tokens and passwords using the [`nats`](../../../../using-nats/nats-tools/nats_cli/readme.md) tool:
 
 ```shell
 nats server passwd


### PR DESCRIPTION
Looks like the folder containing the nats CLI files has been renamed (see commit d253fbb690e26bf771ed39481cfbadcc6c98f03b) and this link was forgotten behind.