### PR TITLE
Quote more consistently in protocol docs

### DIFF
--- a/reference/nats-protocol/nats-protocol/README.md
+++ b/reference/nats-protocol/nats-protocol/README.md
@@ -12,7 +12,7 @@ The NATS server implements a [zero allocation byte parser](https://youtu.be/ylRK
 
 **Control line w/Optional Content**: Each interaction between the client and server consists of a control, or protocol, line of text followed, optionally by message content. Most of the protocol messages don't require content, only `PUB` and `MSG` include payloads.
 
-**Field Delimiters**: The fields of NATS protocol messages are delimited by whitespace characters '\`\`\`'(space) or\`\`\t\` (tab). Multiple whitespace characters will be treated as a single field delimiter.
+**Field Delimiters**: The fields of NATS protocol messages are delimited by whitespace characters ` `(space) or `	`(tab). Multiple whitespace characters will be treated as a single field delimiter.
 
 **Newlines**: NATS uses `CR` followed by `LF` (`CR+LF`, `\r`, `0x0D0A`) to terminate protocol messages. This newline sequence is also used to mark the end of the message payload in a `PUB` or `MSG` protocol message.
 

--- a/reference/nats-protocol/nats-protocol/README.md
+++ b/reference/nats-protocol/nats-protocol/README.md
@@ -10,7 +10,7 @@ The NATS server implements a [zero allocation byte parser](https://youtu.be/ylRK
 
 ## Protocol conventions
 
-**Control line w/Optional Content**: Each interaction between the client and server consists of a control, or protocol, line of text followed, optionally by message content. Most of the protocol messages don't require content, only `PUB` and `MSG` include payloads.
+**Control Line with Optional Content**: Each interaction between the client and server consists of a control, or protocol, line of text followed, optionally by message content. Most of the protocol messages don't require content, only `PUB` and `MSG` include payloads.
 
 **Field Delimiters**: The fields of NATS protocol messages are delimited by whitespace characters ` `(space) or `	`(tab). Multiple whitespace characters will be treated as a single field delimiter.
 

--- a/reference/nats-protocol/nats-protocol/README.md
+++ b/reference/nats-protocol/nats-protocol/README.md
@@ -16,13 +16,13 @@ The NATS server implements a [zero allocation byte parser](https://youtu.be/ylRK
 
 **Newlines**: NATS uses `CR` followed by `LF` (`CR+LF`, `\r`, `0x0D0A`) to terminate protocol messages. This newline sequence is also used to mark the end of the message payload in a `PUB` or `MSG` protocol message.
 
-**Subject names**: Subject names, including reply subject (INBOX) names, are case-sensitive and must be non-empty alphanumeric strings with no embedded whitespace. All ascii alphanumeric characters except spaces/tabs and separators which are "." and ">" are allowed. Subject names can be optionally token-delimited using the dot character (`.`), e.g.:
+**Subject names**: Subject names, including reply subject (INBOX) names, are case-sensitive and must be non-empty alphanumeric strings with no embedded whitespace. All ascii alphanumeric characters except spaces/tabs and separators which are `.` and `>` are allowed. Subject names can be optionally token-delimited using the dot character (`.`), e.g.:
 
 `FOO`, `BAR`, `foo.bar`, `foo.BAR`, `FOO.BAR` and `FOO.BAR.BAZ` are all valid subject names
 
 `FOO. BAR`, `foo. .bar` and`foo..bar` are _not_ valid subject names
 
-A subject is comprised of 1 or more tokens. Tokens are separated by "." and can be any non space ascii alphanumeric character. The full wildcard token ">" is only valid as the last token and matches all tokens past that point. A token wildcard, "\*" matches any token in the position it was listed. Wildcard tokens should only be used in a wildcard capacity and not part of a literal token.
+A subject is comprised of 1 or more tokens. Tokens are separated by `.` and can be any non space ascii alphanumeric character. The full wildcard token `>` is only valid as the last token and matches all tokens past that point. A token wildcard, `*` matches any token in the position it was listed. Wildcard tokens should only be used in a wildcard capacity and not part of a literal token.
 
 **Character Encoding**: Subject names should be ascii characters for maximum interoperability. Due to language constraints and performance, some clients may support UTF-8 subject names, as may the server. No guarantees of non-ASCII support are provided.
 


### PR DESCRIPTION
Noticed invalid rendering of "space" and "tab". Fixed those and then noticed the doc usually uses backticks for quoting literal values - made that consistent as well.

Should INBOX be quoted as well? The occurrence is visible in the diff.

## Commits

- fix(protocol): print a space and a tab in "Field Delimiters"
- fix: quote consistently
- fix: write with instead of w/


