### PR TITLE
Fix broken links for authentication details

### DIFF
--- a/using-nats/developing-with-nats/connecting/README.md
+++ b/using-nats/developing-with-nats/connecting/README.md
@@ -18,11 +18,11 @@ When connecting to a cluster it is best to provide the complete set of 'seed' UR
 ## Authentication details
 
 1. If required: authentication details for the application to identify itself with the NATS server(s). NATS supports multiple authentication schemes:
-   * [Username/Password credentials](../security/userpass.md) (which can be passed as part of the NATS URL)
-   * [Decentralized JWT Authentication/Authorization](../security/creds.md) (where the application is configured with the location of 'credentials file' containing the JWT and private Nkey)
-   * [Token Authentication](../security/token.md#connecting-with-a-token) (where the application is configured with a Token string)
-   * [TLS Certificate](../security/tls.md#connecting-with-tls-and-verify-client-identity) (where the client is configured to use a client TLS certificate and the servers are configured to map the TLS client certificates to users defined in the server configuration)
-   * [NKEY with Challenge](../security/nkey.md) (where the client is configured with a Seed and User NKeys)
+   * [Username/Password credentials](./security/userpass.md) (which can be passed as part of the NATS URL)
+   * [Decentralized JWT Authentication/Authorization](./security/creds.md) (where the application is configured with the location of 'credentials file' containing the JWT and private Nkey)
+   * [Token Authentication](./security/token.md#connecting-with-a-token) (where the application is configured with a Token string)
+   * [TLS Certificate](./security/tls.md#connecting-with-tls-and-verify-client-identity) (where the client is configured to use a client TLS certificate and the servers are configured to map the TLS client certificates to users defined in the server configuration)
+   * [NKEY with Challenge](./security/nkey.md) (where the client is configured with a Seed and User NKeys)
 
 ### Runtime configuration
 


### PR DESCRIPTION
The title speaks for itself. Apparently the `README.md` file was moved at some point, without taking in account the relative link paths.