### PR TITLE
Revise to seperate output and command

### DIFF
--- a/running-a-nats-service/configuration/leafnodes/jetstream_leafnodes.md
+++ b/running-a-nats-service/configuration/leafnodes/jetstream_leafnodes.md
@@ -231,8 +231,13 @@ Obtaining Stream stats
 ├────────┼─────────┼───────────┼──────────┼───────┼──────┼─────────┼──────────┤
 │ test   │ File    │ 0         │ 1        │ 45 B  │ 0    │ 0       │          │
 ╰────────┴─────────┴───────────┴──────────┴───────┴──────┴─────────┴──────────╯
+```
 
-> nats  --server nats://acc:acc@localhost:4222 stream report --js-domain hub
+```bash
+nats  --server nats://acc:acc@localhost:4222 stream report --js-domain hub
+```
+Output
+```text
 Obtaining Stream stats
 
 ╭─────────────────────────────────────────────────────────────────────────────╮
@@ -570,7 +575,13 @@ Obtaining Stream stats
 │ backup-test-leaf    │ Mirror │ $JS.leaf.API │ test          │ 1.85s  │ 0   │       │
 │ aggregate-test-leaf │ Source │ $JS.leaf.API │ test          │ 1.85s  │ 0   │       │
 ╰─────────────────────┴────────┴──────────────┴───────────────┴────────┴─────┴───────╯
-> nats  --server nats://acc:acc@localhost:4222 consumer report --js-domain hub
+```
+
+```bash
+nats  --server nats://acc:acc@localhost:4222 consumer report --js-domain hub
+```
+Output
+```text
 ? Select a Stream aggregate-test-leaf
 ╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │                          Consumer report for aggregate-test-leaf with 1 consumers                           │


### PR DESCRIPTION
For now, our command and output are combined together like this, it's easy to miss this one command. So I revised it and separate them.
<img width="829" alt="image" src="https://user-images.githubusercontent.com/52945328/164254140-0bbe0ae1-a67b-43f5-afa6-0afa469cc53c.png">

Thanks for reviewing:)
@matthiashanel 
