### PR TITLE
Fix the operator name

### DIFF
--- a/using-nats/nats-tools/nsc/basics.md
+++ b/using-nats/nats-tools/nsc/basics.md
@@ -22,7 +22,7 @@ Let’s run through the process of creating some identities and JWTs and work th
 
 ## Creating an Operator, Account and User
 
-Let’s create an operator called `Operator`:
+Let’s create an operator called `MyOperator`:
 
 ```bash
 nsc add operator MyOperator


### PR DESCRIPTION
The old one:
> Let’s create an operator called `Operator`:
```bash
nsc add operator MyOperator
```
It should be `MyOperator`, instead of `Operator`.
Thanks, @matthiashanel 