### PR TITLE
JetStream Disaster Recovery revised and updated for clustered mode and latest NATS CLI backup

### DIFF
--- a/running-a-nats-service/nats_admin/jetstream_admin/disaster_recovery.md
+++ b/running-a-nats-service/nats_admin/jetstream_admin/disaster_recovery.md
@@ -1,24 +1,44 @@
 # Disaster Recovery
 
-Disaster Recovery of the JetStream system is a topic we are still exploring and fleshing out and that will be impacted by the clustering work. For example replication will extend the options available to you.
+In the event of unrecoverable JetStream message persistence on one (or more) server nodes, there are two recovery scenarios:
 
-Today we have a few approaches to consider:
+* Automatic recovery from intact quorum nodes
+* Manual recovery from existing stream snapshots (backups)
 
-* `nats` CLI + Configuration Backups + Data Snapshots
-* Configuration Management + Data Snapshots
+{% hint style="danger" %}
+For R1 streams, data is persisted on one server node only. If that server node is unrecoverable then recovery from
+backup is the sole option.
+{% endhint %}
 
-## Data Backup
+## Automatic Recovery
 
-In all scenarios you can perform data snapshots and restores over the NATS protocol. This is good if you do not manage the NATS servers hosting your data, and you wish to do a backup of your data.
+NATS will create replacement stream replicas automatically under the following conditions:
 
-The backup includes:
+* Impacted stream is of replica configuration R3 (or greater)
+* Remaining intact nodes (stream replicas) meet minimum RAFT quorum: floor(R/2) + 1
+* Available node(s) in the stream's cluster for new replica(s)
+* Impacted node(s) removed from the stream's domain RAFT Meta group (e.g. `nats server raft peer-remove`)
+
+## Manual Recovery
+
+Snapshots (also known as backups) can pro-actively be made of any stream regardless of replication configuration.
+
+The backup includes (by default):
 
 * Stream configuration and state
-* Stream Consumer configuration and state
-* All data including metadata like timestamps and headers
+* Stream durable consumer configuration and state
+* All message payload data including metadata like timestamps and headers
+
+### Backup
+
+The `nats stream backup` CLI command is used to create snapshots of a stream and its durable consumers.
+
+{% hint style="info" %}
+As an account owner, if you wish to make a backup of ALL streams in your account, you may use `nats account backup` instead.
+{% endhint %}
 
 ```shell
-nats stream backup ORDERS /data/js-backup/ORDERS.tgz
+nats stream backup ORDERS '/data/js-backup/backup1'
 ```
 Output
 ```text
@@ -29,20 +49,27 @@ Starting backup of Stream "ORDERS" with 13 data blocks
 Received 13 MiB bytes of compressed data in 3368 chunks for stream "ORDERS" in 1.223428188s, 813 MiB uncompressed
 ```
 
-During the backup the Stream is in a state where it's configuration cannot change and no data will be expired from it based on Limits or Retention Policies.
+During a backup operation, the stream is placed in a status where it's configuration cannot change and no data will be
+evicted based on stream retention policies.
 
+{% hint style="info" %}
 Progress using the terminal bar can be disabled using `--no-progress`, it will then issue log lines instead.
+{% endhint %}
 
-## Restoring Data
+### Restore
 
-The backup made above can be restored into another server - but into the same Stream name.
+An existing backup (as above) can be restored to the same or a new NATS server (or cluster) using the `nats stream restore` command.
+
+{% hint style="info" %}
+If there are multiple streams in the backup directory, they will all be restored.
+{% endhint %}
 
 ```shell
-nats str restore ORDERS /data/js-backup/ORDERS.tgz
+nats stream restore '/data/js-backup/backup1'
 ```
 Output
 ```text
-Starting restore of Stream "ORDERS" from file "/data/js-backup/ORDERS.tgz"
+Starting restore of Stream "ORDERS" from file "/data/js-backup/backup1"
 
 13 MiB/s [====================================================================] 100%
 
@@ -56,43 +83,6 @@ Configuration:
 ...
 ```
 
-The `/data/js-backup/ORDERS.tgz` file can also be extracted into the data dir of a stopped NATS Server.
-
-Progress using the terminal bar can be disabled using `--no-progress`, it will then issue log lines instead.
-
-## Interactive CLI
-
-In environments where the `nats` CLI is used interactively to configure the server you do not have a desired state to recreate the server from. This is not the ideal way to administer the server, we recommend Configuration Management, but many will use this approach.
-
-Here you can back up the configuration into a directory from where you can recover the configuration later. The data for File backed stores can also be backed up.
-
-```shell
-nats backup /data/js-backup
-```
-Output
-```text
-15:56:11 Creating JetStream backup into /data/js-backup
-15:56:11 Stream ORDERS to /data/js-backup/stream_ORDERS.json
-15:56:11 Consumer ORDERS > NEW to /data/js-backup/stream_ORDERS_consumer_NEW.json
-15:56:11 Configuration backup complete
-```
-
-This backs up Stream and Consumer configuration.
-
-During the same process the data can also be backed up by passing `--data`, this will create files like `/data/js-backup/stream_ORDERS.tgz`.
-
-Later the data can be restored, for Streams we support editing the Stream configuration in place to match what was in the backup.
-
-```shell
-nats restore /tmp/backup --update-streams
-```
-Output
-```text
-15:57:42 Reading file /tmp/backup/stream_ORDERS.json
-15:57:42 Reading file /tmp/backup/stream_ORDERS_consumer_NEW.json
-15:57:42 Updating Stream ORDERS configuration
-15:57:42 Restoring Consumer ORDERS > NEW
-```
-
-The `nats restore` tool does not support restoring data, the same process using `nats stream restore`, as outlined earlier, can be used which will also restore Stream and Consumer configurations and state.
-
+{% hint style="warning" %}
+On restore, if a stream already exists in the server of same name and account, you will receive a `Stream {name} already exist` error.
+{% endhint %}


### PR DESCRIPTION
Simplified and updated JetStream Disaster Recovery documentation.  Now reflects clustered streams with replicas and cleans up some NATS CLI backup examples that were outdated.