### PR TITLE
update docs to match natsbox

### DIFF
--- a/running-a-nats-service/nats-on-kubernetes/nats-kubernetes.md
+++ b/running-a-nats-service/nats-on-kubernetes/nats-kubernetes.md
@@ -33,8 +33,8 @@ kubectl exec -n default -it deployment/my-nats-box -- /bin/sh -l
 and try subscribing and publishing
 
 ```bash
-nats-box:~# nats-sub test &
-nats-box:~# nats-pub test hi
+nats-box:~# nats sub test &
+nats-box:~# nats pub test hi
 ```
 
 If you're seeing the messages, all went well and you have successfully installed NATS.


### PR DESCRIPTION
Just started on nats so was going through the guide and realised nats-sub and nats-pub was giving /bin/sh: not found error.

