### PR TITLE
Typo and Suggestions

### DIFF
--- a/nats-concepts/core-nats/publish-subscribe/pubsub_walkthrough.md
+++ b/nats-concepts/core-nats/publish-subscribe/pubsub_walkthrough.md
@@ -28,7 +28,7 @@ nats sub msg.test
 
 You should see the message: _Listening on \[msg.test\]_
 
-### 2. Create a Publisher
+### 2. Create a Publisher and publish a message
 
 In another shell or command prompt, create a NATS publisher and send a message.  
 
@@ -41,7 +41,7 @@ Where `<subject>` is the subject name and `<message>` is the text to publish.
 For example:
 
 ```bash
-nats pub msg.test hello
+nats pub msg.test nats-message-1
 ```
 
 ### 3. Verify message publication and receipt

--- a/nats-concepts/jetstream/readme.md
+++ b/nats-concepts/jetstream/readme.md
@@ -61,7 +61,7 @@ You can impose the following limits on a stream
 
 You must also select a **discard policy** which specifies what should happen once the stream has reached one of its limits and a new message is published:
 * _discard old_ means that the stream will automatically delete the oldest message in the stream to make room for the new messages.
-* _disacrd new_ means that the new message is discarded (and the JetStream publish call returns an error indicating that a limit was reached).
+* _discard new_ means that the new message is discarded (and the JetStream publish call returns an error indicating that a limit was reached).
 
 **Retention policy**
 


### PR DESCRIPTION
* Fixes typo
* When working through the docs I found it confusing to have a header saying 'create publisher' and the next being 'publish another message'. 