### PR TITLE
'exactly once semantics' (i.e. for consumption more than just delivery) is more accurate than 'exactly once delivery'

### DIFF
--- a/nats-concepts/jetstream/readme.md
+++ b/nats-concepts/jetstream/readme.md
@@ -113,7 +113,7 @@ When using the JetStream publish calls to publish to streams there is an acknowl
 
 On the subscriber side the sending of messages from the nats server to the client applications receiving or consuming messages from streams is also flow controlled.
 
-### Exactly once message delivery
+### Exactly once semantics
 
 Because publications to streams using the JetStream publish calls are acknowledged by the server the base quality of service offered by streams is '_at least once_', meaning that while reliable and normally duplicate free there are some specific failure scenarios that could result in a publishing application believing (wrongly) that a message was not published successfully and therefore publishing it again, and there are failure scenarios that could result in a client application's consumption acknowledgement getting lost and therefore in the message being re-sent to the consumer by the server. Those failure scenarios while being rare and even difficult to reproduce do exist and can result in perceived 'message duplication' at the application level.
 

--- a/reference/faq.md
+++ b/reference/faq.md
@@ -37,7 +37,7 @@ NATS is an open source, lightweight, high-performance cloud native infrastructur
 NATS is offered in two interoperable modules in a single "NATS Server" binary \(often referred to as `nats-server` throughout this site\):
 
 * 'Core NATS' is the set of core NATS functionalities and qualities of service.
-* ['JetStream'](/using-nats/jetstream/develop_jetstream.md) is the (optionally enabled) built-in persistence layer that adds streaming, at-least-once and exactly-once delivery guarantees, historical data replay, decoupled flow-control and key/value store functionalities to Core NATS.
+* ['JetStream'](/using-nats/jetstream/develop_jetstream.md) is the (optionally enabled) built-in persistence layer that adds streaming, at-least-once and exactly-once guarantees, historical data replay, decoupled flow-control and key/value store functionalities to Core NATS.
 
 NATS was created by Derek Collison, who has over 25 years of experience designing, building, and using publish-subscribe messaging systems. NATS is maintained by an amazing Open Source Ecosystem, find more at [GitHub](https://www.github.com/nats-io).
 

--- a/using-nats/jetstream/model_deep_dive.md
+++ b/using-nats/jetstream/model_deep_dive.md
@@ -238,9 +238,9 @@ All of these acknowledgement modes, except `AckNext`, support double acknowledge
 
 The `+NXT` acknowledgement can have a few formats: `+NXT 10` requests 10 messages and `+NXT {"no_wait": true}` which is the same data that can be sent in a Pull Request.
 
-## Exactly Once Delivery
+## Exactly Once Semantics
 
-JetStream supports Exactly Once delivery by combining Message Deduplication and double acks.
+JetStream supports Exactly Once publication and consumption by combining Message Deduplication and double acks.
 
 On the publishing side you can avoid duplicate message ingestion using the [Message Deduplication](model_deep_dive.md#message-deduplication) feature.
 


### PR DESCRIPTION
(see slack thread: https://natsio.slack.com/archives/CM3T6T7JQ/p1656590538557769)