### PR TITLE
Fix publish command to use a request

### DIFF
--- a/nats-concepts/core-nats/queue-groups/queues_walkthrough.md
+++ b/nats-concepts/core-nats/queue-groups/queues_walkthrough.md
@@ -43,7 +43,7 @@ You should see that only one of the my-queue group subscribers receives the mess
 ### 6. Publish another message
 
 ```bash
-nats pub foo "Another simple request"
+nats request foo "Another simple request"
 ```
 
 You should see that a different queue group subscriber receives the message this time, chosen at random among the 3 queue group members.


### PR DESCRIPTION
Hej there,

first of all thank you for the awesome introduction documentation and walkthroughs! 🙏 🥰 

While running them locally I was successfully able to follow along, and in step 6 - when publishing a second message to the three spawned queue group members - I received the following:

```
11:35:15 [#0] Received on subject "foo":

Another simple request
11:35:15 Could not publish reply: nats: message does not have a reply
```

I believe this is due to the use of `pub` rather than `request` (like done in step 4). There could be two cases now:

1. Just accidentally used the wrong CLI command.
2. You want to highlight that you can still publish messages without a reply subject. If that's the case, please let me know and I can add a sentence or two on the expected outcome for those cases.