### PR TITLE
Updated the nats unsubscribe to match the nats-py library

### DIFF
--- a/using-nats/developing-with-nats/receiving/unsubscribing.md
+++ b/using-nats/developing-with-nats/receiving/unsubscribing.md
@@ -79,11 +79,11 @@ async def cb(msg):
   nonlocal future
   future.set_result(msg)
 
-sid = await nc.subscribe("updates", cb=cb)
+sub = await nc.subscribe("updates", cb=cb)
 await nc.publish("updates", b'All is Well')
 
 # Remove interest in subject
-await nc.unsubscribe(sid)
+await sub.unsubscribe()
 
 # Won't be received...
 await nc.publish("updates", b'...')


### PR DESCRIPTION
as per this example in the [nats-py](https://github.com/nats-io/nats.py) repo unsubscribe works slightly differently now. This PR just updates the documentation


```python
    # Simple publisher and async subscriber via coroutine.
    sub = await nc.subscribe("foo", cb=message_handler)

    # Stop receiving after 2 messages.
    await sub.unsubscribe(limit=2)
```    