### PR TITLE
Stream and consumer names can not have \ or / in them

### DIFF
--- a/nats-concepts/jetstream/consumers.md
+++ b/nats-concepts/jetstream/consumers.md
@@ -16,6 +16,9 @@ Some messages may cause your applications to crash and cause a never ending loop
 
 To assist with creating monitoring applications, one can set a `SampleFrequency` which is a percentage of messages for which the system should sample and create events. These events will include delivery counts and ack waits.
 
+### Consumer names
+Consumer names should not contain any of the following characters: ` ` (space), `.`, `*`, `>`, or a path separator (forward or backwards slash) or any non-printable characters.
+# Consumer configuration
 When defining Consumers the items below make up the entire configuration of the Consumer:
 
 ## AckPolicy

--- a/nats-concepts/jetstream/streams.md
+++ b/nats-concepts/jetstream/streams.md
@@ -30,3 +30,5 @@ When defining Streams the items below make up the entire configuration of the se
 | Discard | When a Stream reaches it's limits either, `DiscardNew` refuses new messages while `DiscardOld` \(default\) deletes old messages |
 | Duplicates | The window within which to track duplicate messages, expressed in nanoseconds. |
 
+## Stream Names
+Stream names should not contain any of the following characters: ` ` (space), `.`, `*`, `>`, or a path separator (forward or backwards slash) or any non-printable characters.

--- a/running-a-nats-service/nats_admin/jetstream_admin/naming.md
+++ b/running-a-nats-service/nats_admin/jetstream_admin/naming.md
@@ -6,11 +6,8 @@ We recommend the following guideline for stream, consumer, and account names:
 
 * Alphanumeric values are recommended.
 * Spaces, tabs, period (`.`), greater than (`>`) or asterisk (`*`) are prohibited.
-*   Limit name length. The JetStream storage directories will include the account,
-
-    stream name, and consumer name, so a generally safe approach would be to keep names
-
-    **under 32 characters.**
+* Path separators (i.e. forward slash and backward slash) are prohibited. 
+* Limit name length: The JetStream storage directories will include the account, stream name, and consumer name, so a generally safe approach would be to keep names **under 32 characters.**
 * Do not use reserved file names like NUL, LPT1, etc.
 * Be aware that some file systems are case insensitive so do not use stream or account names that would collide in a file system. For example, `Foo` and `foo` would collide on a Windows or Mac OSx System. &#x20;
 


### PR DESCRIPTION
Specifies that stream and consumer names can not have / or \ in them