### PR TITLE
Fix broken link in natsbench page

### DIFF
--- a/using-nats/nats-tools/nats_cli/natsbench.md
+++ b/using-nats/nats-tools/nats_cli/natsbench.md
@@ -4,7 +4,7 @@ NATS is fast and lightweight and places a priority on performance. the `nats` CL
 
 ## Prerequisites
 
-* [Install the NATS CLI Tool](/using-nats/nats-tools/nats-tools/natscli.md)
+* [Install the NATS CLI Tool](./readme.md)
 * [Install the NATS server](../../../running-a-nats-service/installation.md)
 
 ## Start the NATS server with monitoring enabled


### PR DESCRIPTION
Current link is broken, see: https://docs.nats.io/using-nats/nats-tools/nats_cli/natsbench
Points to: https://github.com/nats-io/nats.docs/blob/master/using-nats/nats-tools/nats-tools/natscli.md (no such page)

There are multiple ways to link to the proper page, I choose the shortest but let me know if you prefer a different path.