### PR TITLE
Document more stream and consumer fields

### DIFF
--- a/nats-concepts/jetstream/consumers.md
+++ b/nats-concepts/jetstream/consumers.md
@@ -218,7 +218,7 @@ The push rate limit _can_ be adjusted after the initial creation of the consumer
 
 ### HeadersOnly
 
-Delivers only the headers of messages in the stream and not the bodies. Additionally adds Nats-Msg-Size header to indicate the size of the removed payload.
+Delivers only the headers of messages in the stream and not the bodies. Additionally adds `Nats-Msg-Size` header to indicate the size of the removed payload.
 
 {% hint style="info" %}
 This field _can_ be updated after the initial creation of the consumer.

--- a/nats-concepts/jetstream/consumers.md
+++ b/nats-concepts/jetstream/consumers.md
@@ -215,3 +215,11 @@ Used to throttle the delivery of messages to the consumer, in bits per second.
 {% hint style="info" %}
 The push rate limit _can_ be adjusted after the initial creation of the consumer
 {% endhint %}
+
+### HeadersOnly
+
+Delivers only the headers of messages in the stream and not the bodies. Additionally adds Nats-Msg-Size header to indicate the size of the removed payload.
+
+{% hint style="info" %}
+This field _can_ be updated after the initial creation of the consumer.
+{% endhint %}

--- a/nats-concepts/jetstream/streams.md
+++ b/nats-concepts/jetstream/streams.md
@@ -30,6 +30,10 @@ When defining Streams the items below make up the entire configuration of the se
 | Retention | How message retention is considered, `LimitsPolicy` \(default\), `InterestPolicy` or `WorkQueuePolicy` |
 | Discard | When a Stream reaches it's limits either, `DiscardNew` refuses new messages while `DiscardOld` \(default\) deletes old messages |
 | Duplicates | The window within which to track duplicate messages, expressed in nanoseconds. |
+| Sealed | Sealed streams do not allow messages to be deleted via limits or API, sealed streams can not be unsealed via configuration update. Can only be set on already created streams via the Update API. |
+| DenyDelete | Restricts the ability to delete messages from a stream via the API. Cannot be changed once set to true. |
+| DenyPurge | Restricts the ability to purge messages from a stream via the API. Cannot be change once set to true. |
+| AllowRollup | Allows the use of the `Nats-Rollup` header to replace all contents of a stream, or subject in a stream, with a single new message. |
 
 ## Stream Names
 Stream names should not contain any of the following characters: ` ` (space), `.`, `*`, `>`, or a path separator (forward or backwards slash) or any non-printable characters.


### PR DESCRIPTION
- Consumer: HeadersOnly
- Stream: DenyDelete, DenyPurge, AllowRollup, Sealed

Signed-off-by: Byron Ruth <b@devel.io>