### PR TITLE
Add section for minimum requirements

### DIFF
--- a/running-a-nats-service/installation.md
+++ b/running-a-nats-service/installation.md
@@ -36,7 +36,7 @@ For high throughput use cases, the network interface card (NIC) or the available
 The table below notes the minimum number of cores and memory with the different combinations of publishers, subscribers, and message rate where the single server or cluster remained stable (not slow nor hitting an out-of-memory). These were tested inside a container with `GOMEMLIMIT` set to 90% of the memory allocation.
 
 | Cluster Size | CPU cores | Memory | Subscribers | Publishers | Publish Rate | Total Message Rate |
-| :--- | :--- | :--- | :--- | :--- | :--- |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 | 1 | 1 | 32 MiB | 1 | 100 | 1000 | 100,000 |
 | 1 | 1 | 64 MiB | 1 | 1000 | 100 | 100,000 |
 | 3 | 1 | 32 MiB | 1 | 1000 | 100 | 100,000 |
@@ -47,7 +47,7 @@ The table below notes the minimum number of cores and memory with the different 
 This table follows the same pattern as above, however the published messages are being received by a stream using file storage with the one replica or three (for a cluster size of three). The subscriber is relying on a "pull consumer" for fetching messages.
 
 | Cluster Size | CPU cores | Memory | Subscribers | Publishers | Publish Rate | Total Message Rate |
-| :--- | :--- | :--- | :--- | :--- | :--- |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 | 1 | 1 | 32 MiB | 1 | 10 | 100 | 1,000 |
 | 1 | 1 | 32 MiB | 1 | 100 | 10 | 1,000 |
 | 1 | 1 | 64 MiB | 1 | 100 | 100 | 10,000 |

--- a/running-a-nats-service/installation.md
+++ b/running-a-nats-service/installation.md
@@ -21,7 +21,7 @@ The following table indicates the current supported NATS server build combinatio
 
 *Note, not all installation methods below have distributions for all OS and architecture combinations.*
 
-## System Requirements
+## Hardware requirements
 
 The NATS server itself has minimal hardware requirements to support small edge devices, but can take advantage of more resources if available.
 

--- a/running-a-nats-service/installation.md
+++ b/running-a-nats-service/installation.md
@@ -21,6 +21,29 @@ The following table indicates the current supported NATS server build combinatio
 
 *Note, not all installation methods below have distributions for all OS and architecture combinations.*
 
+## System Requirements
+
+The NATS server itself has minimal hardware requirements to support small edge devices, but can take advantage of more resources if available. For high throughput use cases, the network interface card (NIC) or the available bandwidth are often the bottleneck.
+
+A core NATS server with one publisher and receiver at ~2M messages/sec will use about 11 MB RSS. CPU should be considered in accepting TLS connections. After a network partition, every disconnected client will attempt to connect to a NATS server in the cluster simultaneously, so CPU on those servers will momentarily spike. When there are many clients this can be mitigated with reconnect jitter settings, and errors can be reduced with longer TLS timeouts, and scaling up cluster sizes.
+
+We highly recommend testing to see if smaller, cheaper machines suffice - often they do! We suggest starting here and adjusting resources after load testing specific to your environment. When using cloud provider instance types make sure the node has a sufficient NIC to support the required bandwidth for the application needs.
+
+#### Core Server
+
+| Resource | Minimum |
+|------|----|
+| Memory | 32 MB |
+| CPU | 1 core |
+
+#### With JetStream
+
+| Resource | Minimum |
+|------|----|
+| Memory | 64 MB |
+| CPU | 1 cores |
+| Storage | Local Disk/Drive |
+
 ## Installing via Docker
 
 With Docker you can install the server easily without scattering binaries and other artifacts on your system. The only pre-requisite is to [install docker](https://docs.docker.com/install).

--- a/running-a-nats-service/installation.md
+++ b/running-a-nats-service/installation.md
@@ -36,7 +36,7 @@ For high throughput use cases, the network interface card (NIC) or the available
 The table below notes the minimum number of cores and memory with the different combinations of publishers, subscribers, and message rate where the single server or cluster remained stable (not slow nor hitting an out-of-memory). These were tested inside a container with `GOMEMLIMIT` set to 90% of the memory allocation.
 
 | Cluster Size | CPU cores | Memory | Subscribers | Publishers | Publish Rate | Total Message Rate |
-|------|----|----|----|----|----|
+| :--- | :--- | :--- | :--- | :--- | :--- |
 | 1 | 1 | 32 MiB | 1 | 100 | 1000 | 100,000 |
 | 1 | 1 | 64 MiB | 1 | 1000 | 100 | 100,000 |
 | 3 | 1 | 32 MiB | 1 | 1000 | 100 | 100,000 |
@@ -47,7 +47,7 @@ The table below notes the minimum number of cores and memory with the different 
 This table follows the same pattern as above, however the published messages are being received by a stream using file storage with the one replica or three (for a cluster size of three). The subscriber is relying on a "pull consumer" for fetching messages.
 
 | Cluster Size | CPU cores | Memory | Subscribers | Publishers | Publish Rate | Total Message Rate |
-|------|----|----|----|----|----|
+| :--- | :--- | :--- | :--- | :--- | :--- |
 | 1 | 1 | 32 MiB | 1 | 10 | 100 | 1,000 |
 | 1 | 1 | 32 MiB | 1 | 100 | 10 | 1,000 |
 | 1 | 1 | 64 MiB | 1 | 100 | 100 | 10,000 |

--- a/running-a-nats-service/installation.md
+++ b/running-a-nats-service/installation.md
@@ -33,10 +33,12 @@ For high throughput use cases, the network interface card (NIC) or the available
 
 ### Core NATS
 
-The table below notes the minimum number of cores and memory with the different combinations of publishers, subscribers, and message rate where the single server or cluster remained stable (not slow nor hitting an out-of-memory). These were tested inside a container with `GOMEMLIMIT` set to 90% of the memory allocation.
+The table below notes the minimum number of cores and memory with the different combinations of publishers, subscribers, and message rate where the single server or cluster remained stable (not slow nor hitting an out-of-memory). These were tested inside containers with `GOMEMLIMIT` set to 90% of the memory allocation and with a 2021-era CPU and SSD for JetStream storage.
+
+All message rates are per second.
 
 | Cluster Size | CPU cores | Memory | Subscribers | Publishers | Publish Rate | Total Message Rate |
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | 1 | 1 | 32 MiB | 1 | 100 | 1000 | 100,000 |
 | 1 | 1 | 64 MiB | 1 | 1000 | 100 | 100,000 |
 | 3 | 1 | 32 MiB | 1 | 1000 | 100 | 100,000 |
@@ -47,7 +49,7 @@ The table below notes the minimum number of cores and memory with the different 
 This table follows the same pattern as above, however the published messages are being received by a stream using file storage with the one replica or three (for a cluster size of three). The subscriber is relying on a "pull consumer" for fetching messages.
 
 | Cluster Size | CPU cores | Memory | Subscribers | Publishers | Publish Rate | Total Message Rate |
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | 1 | 1 | 32 MiB | 1 | 10 | 100 | 1,000 |
 | 1 | 1 | 32 MiB | 1 | 100 | 10 | 1,000 |
 | 1 | 1 | 64 MiB | 1 | 100 | 100 | 10,000 |

--- a/running-a-nats-service/installation.md
+++ b/running-a-nats-service/installation.md
@@ -23,26 +23,39 @@ The following table indicates the current supported NATS server build combinatio
 
 ## System Requirements
 
-The NATS server itself has minimal hardware requirements to support small edge devices, but can take advantage of more resources if available. For high throughput use cases, the network interface card (NIC) or the available bandwidth are often the bottleneck.
+The NATS server itself has minimal hardware requirements to support small edge devices, but can take advantage of more resources if available.
 
-A core NATS server with one publisher and receiver at ~2M messages/sec will use about 11 MB RSS. CPU should be considered in accepting TLS connections. After a network partition, every disconnected client will attempt to connect to a NATS server in the cluster simultaneously, so CPU on those servers will momentarily spike. When there are many clients this can be mitigated with reconnect jitter settings, and errors can be reduced with longer TLS timeouts, and scaling up cluster sizes.
+CPU should be considered in accepting TLS connections. After a network partition, every disconnected client will attempt to connect to a NATS server in the cluster simultaneously, so CPU on those servers will momentarily spike. When there are many clients this can be mitigated with reconnect jitter settings, and errors can be reduced with longer TLS timeouts, and scaling up cluster sizes.
 
-We highly recommend testing to see if smaller, cheaper machines suffice - often they do! We suggest starting here and adjusting resources after load testing specific to your environment. When using cloud provider instance types make sure the node has a sufficient NIC to support the required bandwidth for the application needs.
+We highly recommend testing to see if smaller, cheaper machines suffice for your workload - often they do! We suggest starting here and adjusting resources after load testing specific to your environment. When using cloud provider instance types make sure the node has a sufficient NIC to support the required bandwidth for the application needs.
 
-#### Core Server
+For high throughput use cases, the network interface card (NIC) or the available bandwidth are often the bottleneck, so ensure the hardware or cloud provider instance types are sufficient for your needs.
 
-| Resource | Minimum |
-|------|----|
-| Memory | 32 MB |
-| CPU | 1 core |
+### Core NATS
 
-#### With JetStream
+The table below notes the minimum number of cores and memory with the different combinations of publishers, subscribers, and message rate where the single server or cluster remained stable (not slow nor hitting an out-of-memory). These were tested inside a container with `GOMEMLIMIT` set to 90% of the memory allocation.
 
-| Resource | Minimum |
-|------|----|
-| Memory | 64 MB |
-| CPU | 1 cores |
-| Storage | Local Disk/Drive |
+| Cluster Size | CPU cores | Memory | Subscribers | Publishers | Publish Rate | Total Message Rate |
+|------|----|----|----|----|----|
+| 1 | 1 | 32 MiB | 1 | 100 | 1000 | 100,000 |
+| 1 | 1 | 64 MiB | 1 | 1000 | 100 | 100,000 |
+| 3 | 1 | 32 MiB | 1 | 1000 | 100 | 100,000 |
+| 3 | 1 | 64 MiB | 1 | 1000 | 100 | 100,000 |
+
+### With JetStream
+
+This table follows the same pattern as above, however the published messages are being received by a stream using file storage with the one replica or three (for a cluster size of three). The subscriber is relying on a "pull consumer" for fetching messages.
+
+| Cluster Size | CPU cores | Memory | Subscribers | Publishers | Publish Rate | Total Message Rate |
+|------|----|----|----|----|----|
+| 1 | 1 | 32 MiB | 1 | 10 | 100 | 1,000 |
+| 1 | 1 | 32 MiB | 1 | 100 | 10 | 1,000 |
+| 1 | 1 | 64 MiB | 1 | 100 | 100 | 10,000 |
+| 1 | 1 | 64 MiB | 1 | 1000 | 10 | 10,000 |
+| 3 | 1 | 32 MiB | 1 | 100 | 10 | 1,000 |
+| 3 | 1 | 64 MiB | 1 | 100 | 100 | 10,000 |
+| 3 | 1 | 64 MiB | 1 | 1000 | 10 | 10,000 |
+| 3 | 1 | 256 MiB | 1 | 1000 | 100 | 100,000 |
 
 ## Installing via Docker
 


### PR DESCRIPTION
This (hopefully) simplifies #321 to focus on the bare minimum requirement no matter the compute environment. The recommended/upper bound is variable, so stating a _preferred_ size doesn't seem all that useful.

After a very basic test, I sort of arbitrarily choose 64MB for a JS-enabled server