### PR TITLE
add docs for no responders

### DIFF
--- a/nats-concepts/core-nats/request-reply/reqreply.md
+++ b/nats-concepts/core-nats/request-reply/reqreply.md
@@ -20,3 +20,14 @@ The increased complexity of modern systems necessitates features like [location 
 ![](../../../.gitbook/assets/reqrepl.svg)
 
 Try NATS request-reply on your own, using a live server by walking through the [request-reply walkthrough.](reqreply_walkthrough.md)
+
+### No responders
+
+When a request is sent to a topic that has no subscribers, it can be convenient to know about it right away. For this use-case, a NATS client can [opt-into no_responder messages](reference/reference-protocols/nats-protocol#connect). This requires a server and client that support headers. When enabled, a request sent to a topic with no subscribers will immediately receive a reply that has no body, and a `503` status.
+
+Most clients will represent this case by raising or returning an error. For example:
+
+```go
+m, err := nc.Request("foo", nil, time.Second);
+# err == nats.ErrNoResponders
+```

--- a/reference/nats-protocol/nats-protocol/README.md
+++ b/reference/nats-protocol/nats-protocol/README.md
@@ -132,6 +132,7 @@ The valid options are as follows:
 * `echo`: Optional boolean. If set to `true`, the server (version 1.2.0+) will not send originating messages from this connection to its own subscriptions. Clients should set this to `true` only for server supporting this feature, which is when `proto` in the `INFO` protocol is set to at least `1`.
 * `sig`: In case the server has responded with a `nonce` on `INFO`, then a NATS client must use this field to reply with the signed `nonce`.
 * `jwt`: The JWT that identifies a user permissions and account.
+* `no_responders`: _optional bool_. Enable [quick replies for cases where a request is sent to a topic with no responders](nats-concepts/core-nats/reqreply#no_responders).
 
 ### Example
 


### PR DESCRIPTION
I have been working on https://github.com/nats-io/nats.ex/pull/137 to add support for no responders to the Elixir client. While working on this I referred to the client protocol docs and didn't find anything about this behavior, so I thought I would embrace the [spirit of Hacktoberfest](https://hacktoberfest.com/) and open a PR to add this documentation.

This is my first time contributing to the NATS docs, so I'm unsure of details like whether the go example is appropriate in the req-reply conceptual doc. Feel free to suggest any and all modifications that will make these docs helpful to the community.