### PR TITLE
Fix broken links on https://docs.nats.io/legacy/nas/notifications

### DIFF
--- a/legacy/nas/notifications.md
+++ b/legacy/nas/notifications.md
@@ -1,8 +1,8 @@
 # Update Notifications
 
-The `nats-account-server` can notify a nats-server about [JWT](../../nats-server/configuration/securing_nats/jwt/) updates, enabling the NATS server to update itself to the newly updated JWT.
+The `nats-account-server` can notify a nats-server about [JWT](../../running-a-nats-service/configuration/securing_nats/jwt/) updates, enabling the NATS server to update itself to the newly updated JWT.
 
-To push notifications, the nats-account-server makes use of [system accounts](../../nats-server/configuration/sys_accounts/).
+To push notifications, the nats-account-server makes use of [system accounts](../../running-a-nats-service/configuration/sys_accounts/#system-account).
 
 Here's a nats-account-server configuration with updates enabled:
 

--- a/running-a-nats-service/configuration/sys_accounts/README.md
+++ b/running-a-nats-service/configuration/sys_accounts/README.md
@@ -18,6 +18,8 @@ These events are enabled by configuring `system_account` and [subscribing/reques
 
 ## Available Events and Services
 
+### System Account
+
 The system account publishes messages under well known subject patterns.
 
 Server initiated events:


### PR DESCRIPTION
This page has a few broken links
https://docs.nats.io/legacy/nas/notifications

Also, add a heading for `System Account`