### PR TITLE
Add a doc with JetStream troubleshooting hints

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -136,6 +136,7 @@
     * [Clustering Configuration](running-a-nats-service/configuration/clustering/cluster_config.md)
     * [JetStream Clustering](running-a-nats-service/configuration/clustering/jetstream_clustering/README.md)
       * [Administration](running-a-nats-service/configuration/clustering/jetstream_clustering/administration.md)
+      * [Troubleshooting](running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md)
   * [Super-cluster with Gateways](running-a-nats-service/configuration/gateways/README.md)
     * [Configuration](running-a-nats-service/configuration/gateways/gateway.md)
   * [Leaf Nodes](running-a-nats-service/configuration/leafnodes/README.md)

--- a/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
+++ b/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
@@ -58,7 +58,7 @@ The following tips and commands (while not an exhaustive list) can be useful whe
 
 | Command | Description |
 | :--- | :--- |
-|  [nats traffic](https://github.com/nats-io/natscli/blob/main/cli/traffic_command.go) |  Monitor NATS traffic. (**Experimental command**) |
+|  [`nats traffic`](https://github.com/nats-io/natscli/blob/main/cli/traffic_command.go) |  Monitor NATS traffic. (**Experimental command**) |
 
 ## Further troubleshooting references
 

--- a/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
+++ b/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
@@ -32,7 +32,7 @@ The following tips and commands (while not an exhaustive list) can be useful whe
 | :--- | :--- |
 | `nats server report connections` |  Report on connections |
 | `nats server report accounts` | Report on account activity |
-| [nats server report jetstream](./administration.md#viewing-the-cluster-state) | Report on JetStream activity |
+| [`nats server report jetstream`](./administration.md#viewing-the-cluster-state) | Report on JetStream activity |
 
 ### `nats server request` commands
 

--- a/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
+++ b/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
@@ -52,7 +52,7 @@ The following tips and commands (while not an exhaustive list) can be useful whe
 | Command | Description |
 | :--- | :--- |
 | [`nats server raft step-down`](./administration.md#forcing-stream-and-consumer-leader-election) | Force a new leader election by standing down the current meta leader |
-| [nats server raft peer-remove](./administration.md#evicting-a-peer) |  Removes a server from a JetStream cluster |
+| [`nats server raft peer-remove`](./administration.md#evicting-a-peer) |  Removes a server from a JetStream cluster |
 
 ### Experimental commands
 

--- a/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
+++ b/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
@@ -1,7 +1,7 @@
 # Troubleshooting NATS JetStream clusters
 
 Diagnosing problems in NATS JetStream clusters requires:
-* knowledge of [JetStream concepts](/nats-concepts/jetstream/#jetstream-1)
+* knowledge of [JetStream concepts](../../../../nats-concepts/jetstream/readme.md)
 * knowledge of the [NATS Command Line Interface (CLI)](https://github.com/nats-io/natscli#the-nats-command-line-interface)
 
 The following tips and commands (while not an exhaustive list) can be useful when diagnosing problems in NATS JetStream clusters:

--- a/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
+++ b/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
@@ -38,7 +38,7 @@ The following tips and commands (while not an exhaustive list) can be useful whe
 
 | Command | Description |
 | :--- | :--- |
-|  [nats server request jetstream](./administration.md#viewing-the-cluster-state) | Show JetStream details |
+|  [`nats server request jetstream`](./administration.md#viewing-the-cluster-state) | Show JetStream details |
 |  `nats server request subscriptions` |  Show subscription information |
 |  `nats server request variables`   |   Show runtime variables |
 |  `nats server request connections` |   Show connection details |

--- a/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
+++ b/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
@@ -51,7 +51,7 @@ The following tips and commands (while not an exhaustive list) can be useful whe
 
 | Command | Description |
 | :--- | :--- |
-| [nats server raft step-down](./administration.md#forcing-stream-and-consumer-leader-election) | Force a new leader election by standing down the current meta leader |
+| [`nats server raft step-down`](./administration.md#forcing-stream-and-consumer-leader-election) | Force a new leader election by standing down the current meta leader |
 | [nats server raft peer-remove](./administration.md#evicting-a-peer) |  Removes a server from a JetStream cluster |
 
 ### Experimental commands

--- a/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
+++ b/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
@@ -1,0 +1,65 @@
+# Troubleshooting NATS JetStream clusters
+
+Diagnosing problems in NATS JetStream clusters requires:
+* knowledge of [JetStream concepts](/nats-concepts/jetstream/#jetstream-1)
+* knowledge of the [NATS Command Line Interface (CLI)](https://github.com/nats-io/natscli#the-nats-command-line-interface)
+
+The following tips and commands (while not an exhaustive list) can be useful when diagnosing problems in NATS JetStream clusters:
+
+## Troubleshooting tips
+
+1. Look at [nats-server](https://github.com/nats-io/nats-server#readme) logs
+2. Make sure that in the [NATS JetStream configuration](./README.md#configuration), at least one system user is configured in this section: `{ $SYS { users } }`.
+
+### `nats account` commands
+
+| Command | Description |
+| :--- | :--- |
+| [nats account info](../../../nats_admin/jetstream_admin/account.md) | Verify that JetStream is enabled on account |
+
+###  Basic `nats server` commands
+
+| Command | Description |
+| :--- | :--- |
+| `nats server ls` | List known servers |
+|  `nats server ping`  |    Ping all servers |
+|  `nats server info`  |    Show information about a single server |
+|  [nats server check](../../../clients.md#testing-your-setup) | Health check for NATS servers |
+
+### `nats server report` commands
+
+| Command | Description |
+| :--- | :--- |
+| `nats server report connections` |  Report on connections |
+| `nats server report accounts` | Report on account activity |
+| [nats server report jetstream](./administration.md#viewing-the-cluster-state) | Report on JetStream activity |
+
+### `nats server request` commands
+
+| Command | Description |
+| :--- | :--- |
+|  [nats server request jetstream](./administration.md#viewing-the-cluster-state) | Show JetStream details |
+|  `nats server request subscriptions` |  Show subscription information |
+|  `nats server request variables`   |   Show runtime variables |
+|  `nats server request connections` |   Show connection details |
+|  `nats server request routes`      |   Show route details |
+|  `nats server request gateways`    |  Show gateway details |
+|  `nats server request leafnodes`   |  Show leafnode details |
+|  `nats server request accounts`    |  Show account details |
+
+### `nats server raft` commands
+
+| Command | Description |
+| :--- | :--- |
+| [nats server raft step-down](./administration.md#forcing-stream-and-consumer-leader-election) | Force a new leader election by standing down the current meta leader |
+| [nats server raft peer-remove](./administration.md#evicting-a-peer) |  Removes a server from a JetStream cluster |
+
+### Experimental commands
+
+| Command | Description |
+| :--- | :--- |
+|  [nats traffic](https://github.com/nats-io/natscli/blob/main/cli/traffic_command.go) |  Monitor NATS traffic. (**Experimental command**) |
+
+## Further troubleshooting references
+
+* [Testing your setup](../../../clients.md#testing-your-setup)

--- a/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
+++ b/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
@@ -15,7 +15,7 @@ The following tips and commands (while not an exhaustive list) can be useful whe
 
 | Command | Description |
 | :--- | :--- |
-| [nats account info](../../../nats_admin/jetstream_admin/account.md) | Verify that JetStream is enabled on account |
+| [`nats account info`](../../../nats_admin/jetstream_admin/account.md) | Verify that JetStream is enabled on account |
 
 ###  Basic `nats server` commands
 

--- a/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
+++ b/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
@@ -24,7 +24,7 @@ The following tips and commands (while not an exhaustive list) can be useful whe
 | `nats server ls` | List known servers |
 |  `nats server ping`  |    Ping all servers |
 |  `nats server info`  |    Show information about a single server |
-|  [nats server check](../../../clients.md#testing-your-setup) | Health check for NATS servers |
+|  [`nats server check`](../../../clients.md#testing-your-setup) | Health check for NATS servers |
 
 ### `nats server report` commands
 

--- a/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
+++ b/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md
@@ -8,7 +8,7 @@ The following tips and commands (while not an exhaustive list) can be useful whe
 
 ## Troubleshooting tips
 
-1. Look at [nats-server](https://github.com/nats-io/nats-server#readme) logs
+1. Look at [nats-server](https://github.com/nats-io/nats-server) logs. By default, only warning and error logs are produced, but debug and trace logs can be turned on from the command line using `-D` and `-DV`, respectively. Alternatively, enabling `debug` or `trace` in the [server config](https://docs.nats.io/running-a-nats-service/configuration#monitoring-and-tracing).
 2. Make sure that in the [NATS JetStream configuration](./README.md#configuration), at least one system user is configured in this section: `{ $SYS { users } }`.
 
 ### `nats account` commands


### PR DESCRIPTION
I put this doc together based on feedback in these Slack threads:
https://natsio.slack.com/archives/C069GSYFP/p1665766924057909?thread_ts=1665764019.736979&cid=C069GSYFP
https://natsio.slack.com/archives/CM3T6T7JQ/p1665656371076639?thread_ts=1665655333.400419&cid=CM3T6T7JQ

The doc fully rendered is here:
https://github.com/nats-io/nats.docs/blob/b6199a6f92ac8826afb08c3d0bd069f4d0d18007/running-a-nats-service/configuration/clustering/jetstream_clustering/troubleshooting.md