### PR TITLE
Improve description of RetryOnFailedConnect

### DIFF
--- a/using-nats/developing-with-nats/reconnect/README.md
+++ b/using-nats/developing-with-nats/reconnect/README.md
@@ -83,4 +83,4 @@ ReconnectBufSize is the size of the backing bufio during reconnect. Once this ha
 
 * `RetryOnFailedConnect bool`
 
-RetryOnFailedConnect sets the connection in reconnecting state right away if it can't connect to a server in the initial set. The *MaxReconnect* and *ReconnectWait* options are used for this process, similarly to when an established connection is disconnected. If a ReconnectHandler is set, it will be invoked when the connection is established, and if a ClosedHandler is set, it will be invoked if it fails to connect (after exhausting the MaxReconnect attempts). Default is `false`
+RetryOnFailedConnect sets the connection in reconnecting state right away if it can't connect to a server in the initial set. The *MaxReconnect* and *ReconnectWait* options are used for this process, similarly to when an established connection is disconnected. If a ReconnectHandler is set, it will be invoked on the first successful reconnect attempt (if the initial connect fails), and if a ClosedHandler is set, it will be invoked if it fails to connect (after exhausting the MaxReconnect attempts). Default is `false`


### PR DESCRIPTION
This addresses https://github.com/nats-io/nats.go/issues/1109, and is a follow-up to updating the comment on `RetryOnFailedConnect` in nats.go: https://github.com/nats-io/nats.go/pull/1127