### PR TITLE
nsc is now v2 from Go perspective

### DIFF
--- a/running-a-nats-service/nats_admin/jwt.md
+++ b/running-a-nats-service/nats_admin/jwt.md
@@ -90,7 +90,7 @@ To exercise listed examples please have the following installed:
 > go install github.com/nats-io/nats-server/v2@latest
 > go install github.com/nats-io/natscli/nats@latest
 > go install github.com/nats-io/nkeys/nk@latest
-> go install github.com/nats-io/nsc@latest
+> go install github.com/nats-io/nsc/v2@latest
 > ```
 > To practice the examples below:
 >


### PR DESCRIPTION
As of nsc `v2.7.6`, it presents as v2 to the Go module namespace perspective,
unlike `2.7.5` (no `v` prefix).  So this install command should be updated.
