### PR TITLE
Fix reference to CLI flag `--auth`

### DIFF
--- a/running-a-nats-service/running/flags.md
+++ b/running-a-nats-service/running/flags.md
@@ -38,8 +38,8 @@ The following options control straightforward authentication:
 
 | Flag     | Description                                                                              |
 | -------- | ---------------------------------------------------------------------------------------- |
-| `--user` | Required _username_ for connections (exclusive of `--token`).                            |
-| `--pass` | Required _password_ for connections (exclusive of `--token`).                            |
+| `--user` | Required _username_ for connections (exclusive of `--auth`).                             |
+| `--pass` | Required _password_ for connections (exclusive of `--auth`).                             |
 | `--auth` | Required _authorization token_ for connections (exclusive of `--user` and `--password`). |
 
 See [token authentication](../configuration/securing_nats/auth_intro/tokens.md), and [username/password](../configuration/securing_nats/auth_intro/username_password.md) for more information.


### PR DESCRIPTION
"token" is the name of the flag's argument, but the name of the flag itself is `--auth`.