### PR TITLE
Nk nsc improvements

### DIFF
--- a/using-nats/nats-tools/nk.md
+++ b/using-nats/nats-tools/nk.md
@@ -30,3 +30,15 @@ The first output line starts with the letter `S` for _Seed_. The second letter `
 
 The second line starts with the letter `U` for _User_, and is a public key which can be safely shared.
 
+To use `nkey` authentication, add a user, and set the `nkey` property to the public key of the user you want to authenticate. You are only required to use the public key and no other properties are required. Here is a snippet of configuration for the `nats-server`:
+
+```
+authorization: {
+  users: [
+    { nkey: UDXU4RCSJNZOIQHZNWXHXORDPRTGNJAHAHFRGZNEEJCPQTT2M7NLCNF4 }
+  ]
+}
+```
+
+To complete the end-to-end configuration and use an `nkey`, the [client is configured](https://docs.nats.io/running-a-nats-service/configuration/securing\_nats/auth\_intro/nkey\_auth#client-configuration) to use the seed, which is the private key.
+

--- a/using-nats/nats-tools/nsc/basics.md
+++ b/using-nats/nats-tools/nsc/basics.md
@@ -344,13 +344,23 @@ At minimum, the server requires the `operator` JWT, which we have pointed at dir
 
 Now start this local test server using `nats-server -c myconfig.cfg`
 
+The nats-server requires a designated account for operations and monitoring of the server, cluster, or supercluster. If you see this error message:
+
+`nats-server: using nats based account resolver - the system account needs to be specified in configuration or the operator jwt`&#x20;
+
+Then there is no system account to interact with the server and you need to add one to the configuration or operator JWT. Let’s add one to the operator JWT using `nsc`:
+
+`nsc edit operator --system-account MyAccount`
+
+Now start the local test server using: `nats-server -c myconfig.cfg`
+
 ## Pushing the local nsc changes to the nats server
 
 In order for the nats servers to know about the account(s) you have created or changes to the attributes for those accounts, you need to push any new accounts or any changes to account attributes you may have done locally using `nsc` into the built-in account resolver of the nats-server. You can do this using `nsc push`:
 
-For example to push the account named 'A' that you have just created into the nats server running locally on your machine use:
+For example to push the account named 'MyAccount' that you have just created into the nats server running locally on your machine use:
 ```shell
-nsc push -a A -u nats://localhost
+nsc push -a MyAccount -u nats://localhost
 ```
 
 You can also use `nsc pull -u nats://localhost` to pull the view of the accounts that the local nats server has into your local nsc copy (i.e. in `~/.nsc`)

--- a/using-nats/nats-tools/nsc/basics.md
+++ b/using-nats/nats-tools/nsc/basics.md
@@ -24,7 +24,7 @@ Let’s run through the process of creating some identities and JWTs and work th
 
 Let’s create an operator called `MyOperator`. 
 
-_There is an additional switch `--sys` that sets up the system account which is required for interacting with the nats server. You can create and set the system account later._
+_There is an additional switch `--sys` that sets up the system account which is required for interacting with the NATS server. You can create and set the system account later._
 
 ```bash
 nsc add operator MyOperator

--- a/using-nats/nats-tools/nsc/basics.md
+++ b/using-nats/nats-tools/nsc/basics.md
@@ -352,8 +352,10 @@ The nats-server requires a designated account for operations and monitoring of t
 
 Then there is no system account to interact with the server and you need to add one to the configuration or operator JWT. Let’s add one to the operator JWT using `nsc`:
 
-`nsc add account -n SYS`
-`nsc edit operator --system-account SYS`
+```shell
+nsc add account -n SYS`
+nsc edit operator --system-account SYS
+```
 
 Now start the local test server using: `nats-server -c myconfig.cfg`
 

--- a/using-nats/nats-tools/nsc/basics.md
+++ b/using-nats/nats-tools/nsc/basics.md
@@ -368,7 +368,7 @@ For example to push the account named 'MyAccount' that you have just created int
 nsc push -a MyAccount -u nats://localhost
 ```
 
-You can also use `nsc pull -u nats://localhost` to pull the view of the accounts that the local nats server has into your local nsc copy (i.e. in `~/.nsc`)
+You can also use `nsc pull -u nats://localhost` to pull the view of the accounts that the local NATS server has into your local nsc copy (i.e. in `~/.nsc`)
 
 As soon as you  'push' an the account JWT to the server (that server's built-in NATS account resolver will take care of distributing that new (or new version of) the account JWT to the other nats servers in the cluster) then the changes will take effect and for example any users you may have created with that account will then be able to connect to any of the nats server in the cluster using the user's JWT.
 ## Client Testing

--- a/using-nats/nats-tools/nsc/basics.md
+++ b/using-nats/nats-tools/nsc/basics.md
@@ -22,7 +22,9 @@ Let’s run through the process of creating some identities and JWTs and work th
 
 ## Creating an Operator, Account and User
 
-Let’s create an operator called `MyOperator`:
+Let’s create an operator called `MyOperator`. 
+
+_There is an additional switch `--sys` that sets up the system account which is required for interacting with the nats server. You can create and set the system account later._
 
 ```bash
 nsc add operator MyOperator
@@ -350,7 +352,8 @@ The nats-server requires a designated account for operations and monitoring of t
 
 Then there is no system account to interact with the server and you need to add one to the configuration or operator JWT. Let’s add one to the operator JWT using `nsc`:
 
-`nsc edit operator --system-account MyAccount`
+`nsc add account -n SYS`
+`nsc edit operator --system-account SYS`
 
 Now start the local test server using: `nats-server -c myconfig.cfg`
 


### PR DESCRIPTION
Some `nk` and `nsc` tool updates.

1. More information on using `nk` because it felt prematurely cut off.
2. I ran into some issues when using `nsc` and opted to mend the problems around the SYS account information.