### PR TITLE
fix(protocol): add missing headers in HMSG message syntax summary

### DIFF
--- a/reference/nats-protocol/nats-protocol/README.md
+++ b/reference/nats-protocol/nats-protocol/README.md
@@ -301,7 +301,7 @@ The `HMSG` message is the same as `MSG`, but extends the message payload with he
 
 ### Syntax
 
-`HMSG <subject> <sid> [reply-to] <#header bytes> <#total bytes>␍␊[payload]␍␊`
+`HMSG <subject> <sid> [reply-to] <#header bytes> <#total bytes>␍␊[headers]␍␊␍␊[payload]␍␊`
 
 where:
 


### PR DESCRIPTION
The protocol description mentions the _headers_ which are the most important thing about the `HMSG` message, but the syntax summary line was missing them.

I have added them in this MR, like in the `HPUB` message docs.