### PR TITLE
Durable consumers are created by passing a durable name to the subscription creation call

### DIFF
--- a/using-nats/developing-with-nats/js/consumers.md
+++ b/using-nats/developing-with-nats/js/consumers.md
@@ -174,7 +174,7 @@ processing, or to persist the position of the consumer over the stream between r
 
 Durable consumers as the name implies are meant to last 'forever' and are typically created and deleted administratively rather than by the application code which only needs to specify the durable's well known name to use it.
 
-You create a durable consumer using the `nats consumer add` CLI tool command, or programmatically by passing a durable name option to the stream creation call.
+You create a durable consumer using the `nats consumer add` CLI tool command, or programmatically by passing a durable name option to the subscription creation call.
 
 ### Push and Pull consumers
 


### PR DESCRIPTION
See Slack discussion: https://natsio.slack.com/archives/CM3T6T7JQ/p1675854866457539?thread_ts=1675818900.865929&cid=CM3T6T7JQ

A Durable Consumer is created by passing a [nats.Durable](https://github.com/nats-io/nats.go/blob/7ca331ad05cb9427216f9227d9950cb4c4d777cb/js.go#L2190) [Subscription option](https://github.com/nats-io/nats.go/blob/7ca331ad05cb9427216f9227d9950cb4c4d777cb/js.go#L1200) to the subscribe call:

```
js.Subscribe("foo", func(msg *nats.Msg){},
nats.Durable("foo_consumer"))
```


[js.Subscribe()](https://github.com/nats-io/nats.go/blob/2ea8d393bbd4eb781462695533a0f1bf321ca7e5/js.go#L925)  creates and returns a [Subscription](https://github.com/nats-io/nats.go/blob/2ea8d393bbd4eb781462695533a0f1bf321ca7e5/nats.go#L532), not a stream