### PR TITLE
Clean up route and remote examples to use 'nats://'

### DIFF
--- a/running-a-nats-service/configuration/clustering/cluster_config.md
+++ b/running-a-nats-service/configuration/clustering/cluster_config.md
@@ -36,8 +36,8 @@ cluster {
   # Other servers can connect to us if they supply the correct credentials
   # in their routes definitions from above.
   routes = [
-    nats-route://route_user:pwd@127.0.0.1:4245
-    nats-route://route_user:pwd@127.0.0.1:4246
+    nats://route_user:pwd@127.0.0.1:4245
+    nats://route_user:pwd@127.0.0.1:4246
   ]
 }
 ```

--- a/running-a-nats-service/configuration/clustering/cluster_tls.md
+++ b/running-a-nats-service/configuration/clustering/cluster_tls.md
@@ -21,7 +21,7 @@ cluster {
   # Other servers can connect to us if they supply the correct credentials
   # in their routes definitions from above.
   routes = [
-    nats-route://127.0.0.1:4246
+    nats://127.0.0.1:4246
   ]
 }
 ```

--- a/running-a-nats-service/configuration/clustering/jetstream_clustering/README.md
+++ b/running-a-nats-service/configuration/clustering/jetstream_clustering/README.md
@@ -76,8 +76,8 @@ cluster {
   name: C1
   listen: 0.0.0.0:6222
   routes: [
-    nats-route://host_b:6222
-    nats-route://host_c:6222
+    nats://host_b:6222
+    nats://host_c:6222
   ]
 }
 ```
@@ -106,8 +106,8 @@ cluster {
   name: C1
   listen: 0.0.0.0:6222
   routes: [
-    nats-route://host_a:6222
-    nats-route://host_c:6222
+    nats://host_a:6222
+    nats://host_c:6222
   ]
 }
 ```
@@ -136,8 +136,8 @@ cluster {
   name: C1
   listen: 0.0.0.0:6222
   routes: [
-    nats-route://host_a:6222
-    nats-route://host_b:6222
+    nats://host_a:6222
+    nats://host_b:6222
   ]
 }
 ```

--- a/running-a-nats-service/configuration/leafnodes/jetstream_leafnodes.md
+++ b/running-a-nats-service/configuration/leafnodes/jetstream_leafnodes.md
@@ -82,11 +82,11 @@ jetstream {
 leafnodes {
     remotes = [
         {
-            urls: ["nats-leaf://admin:admin@0.0.0.0:7422"]
+            urls: ["nats://admin:admin@0.0.0.0:7422"]
             account: "SYS"
         },
         {
-            urls: ["nats-leaf://acc:acc@0.0.0.0:7422"]
+            urls: ["nats://acc:acc@0.0.0.0:7422"]
             account: "ACC"
         }
     ]

--- a/running-a-nats-service/configuration/leafnodes/leafnode_conf.md
+++ b/running-a-nats-service/configuration/leafnodes/leafnode_conf.md
@@ -128,7 +128,7 @@ Note that if a URL has the `ws` scheme, all URLs the list must be `ws`. You cann
 ```
   remotes [
     # Invalid configuration that will prevent the server from starting
-    {urls: ["ws://hostname1:443", "nats-leaf://hostname2:7422"]}
+    {urls: ["ws://hostname1:443", "nats://hostname2:7422"]}
   ]
 ```
 

--- a/running-a-nats-service/nats_admin/jwt.md
+++ b/running-a-nats-service/nats_admin/jwt.md
@@ -1692,11 +1692,11 @@ The outgoing connection is not in Operator mode, thus the system account may dif
 leafnodes {
     remotes = [
         {
-          url: "nats-leaf://localhost:4222"
+          url: "nats://localhost:4222"
           credentials: "./your-account.creds"
         },
         {
-          url: "nats-leaf://localhost:4222"
+          url: "nats://localhost:4222"
           account: "$SYS"
           credentials: "./system-account.creds"
         },
@@ -1714,12 +1714,12 @@ system_account: AAAXAUVSGK7TCRHFIRAS4SYXVJ76EWDMNXZM6ARFGXP7BASNDGLKU7A5
 leafnodes {
     remotes = [
         {
-          url: "nats-leaf://localhost:4222"
+          url: "nats://localhost:4222"
           account: "ADKGAJU55CHYOIF5H432K2Z2ME3NPSJ5S3VY5Q42Q3OTYOCYRRG7WOWV"
           credentials: "./your-account.creds"
         },
         {
-          url: "nats-leaf://localhost:4222"
+          url: "nats://localhost:4222"
           account: "AAAXAUVSGK7TCRHFIRAS4SYXVJ76EWDMNXZM6ARFGXP7BASNDGLKU7A5"
           credentials: "./system-account.creds"
         },


### PR DESCRIPTION
Homogenize the route and LN remote URLs to just use 'nats://' removing some confusion for the reader as to whether there is  a differece between using 'nats://' or 'nats-route://' or 'nats-leaf://' (there isn't)