### PR TITLE
config options leafnode -> leafnodes

### DIFF
--- a/running-a-nats-service/configuration/README.md
+++ b/running-a-nats-service/configuration/README.md
@@ -121,7 +121,7 @@ authorization: {
 | `client_advertise` | Alternative client listen specification `<host>:<port>` or just `<host>` to advertise to clients and other server. Useful in [cluster](clustering/cluster_config.md) setups with NAT. | Advertise what `host` and `port` specify. |
 | [`tls`](/running-a-nats-service/configuration/securing_nats/tls.md) | Configuration map for tls for client and http monitoring. |  |
 | [`gateway`](/running-a-nats-service/configuration/gateways/gateway.md#gateway-configuration-block) | Configuration map for [gateway](/running-a-nats-service/configuration/gateways). |  |
-| [`leafnode`](/running-a-nats-service/configuration/leafnodes/leafnode_conf.md) | Configuration map for a [leafnode](/running-a-nats-service/configuration/leafnodes). |  |
+| [`leafnodes`](/running-a-nats-service/configuration/leafnodes/leafnode_conf.md) | Configuration map for [leafnodes](/running-a-nats-service/configuration/leafnodes). |  |
 | [`mqtt`](/running-a-nats-service/configuration/mqtt/mqtt_config.md) | Configuration map for [mqtt](/running-a-nats-service/configuration/mqtt). |  |
 | [`websocket`](/running-a-nats-service/configuration/websocket/websocket_conf.md) | Configuration map for [websocket](/running-a-nats-service/configuration/websocket). |  |
 


### PR DESCRIPTION
Singular `leafnode` is not an option, standardize to `leafnodes`

https://github.com/nats-io/nats-server/blob/5db57fb053a03dd84928ed84fb14da9e2267d1eb/server/opts.go#L902-L907