### PR TITLE
Correct Syslog and describe used standard

### DIFF
--- a/running-a-nats-service/configuration/logging.md
+++ b/running-a-nats-service/configuration/logging.md
@@ -40,22 +40,23 @@ If `-T false` then log entries are not timestamped. Default is true.
 
 #### Syslog
 
+NATS Server follows the RFC5424 protocol standard and uses non transparent framing.
 You can configure syslog with `UDP`:
 
 ```bash
 nats-server -r udp://localhost:514
 ```
 
-or `syslog:`
+or `tcp:`
 
 ```bash
-nats-server -r syslog://<hostname>:<port>
+nats-server -r tcp://<hostname>:<port>
 ```
 
 For example:
 
 ```bash
-syslog://logs.papertrailapp.com:26900
+tcp://logs.papertrailapp.com:26900
 ```
 
 ### Using the Configuration File


### PR DESCRIPTION
nats-server doesn't recognize `syslog`as a protocol:
```
2023/11/14 10:23:31 error invalid network type: "syslog"
```
It should probably say tcp instead of syslog.

On what I could find, NATS Server sends RFC5424 protocol based messages with non transparent framing.
This information is important for configuring Syslog receivers.