### PR TITLE
Add TLS example Link

### DIFF
--- a/running-a-nats-service/configuration/securing_nats/tls.md
+++ b/running-a-nats-service/configuration/securing_nats/tls.md
@@ -200,3 +200,7 @@ See: <https://github.com/nats-io/nats.js/issues/369>
 ### nats.rs
 
 See: <https://github.com/nats-io/nats.rs/blob/main/async-nats/src/connector.rs>
+
+### nats.net
+
+See: <https://github.com/nats-io/nats.net/tree/main/src/Samples/TLSReverseProxyExample>


### PR DESCRIPTION
Adds a link to the TLS/Custom TCPClient example for c#