### PR TITLE
nk: fix installation instructions

### DIFF
--- a/using-nats/nats-tools/nk.md
+++ b/using-nats/nats-tools/nk.md
@@ -11,7 +11,7 @@ With NKeys the server can verify identity without ever storing secrets on the se
 To get started with NKeys, you’ll need the `nk` tool from [https://github.com/nats-io/nkeys/tree/master/nk](https://github.com/nats-io/nkeys/tree/master/nk) repository. If you have _go_ installed, enter the following at a command prompt:
 
 ```bash
-go get github.com/nats-io/nkeys/nk
+go install github.com/nats-io/nkeys/nk@latest
 ```
 
 ## Generating NKeys and Configuring the Server


### PR DESCRIPTION
- `go get` [is deprecated](https://golang.org/doc/go-get-install-deprecation) for installing binaries
- supplying an actual version (instead of `@latest`) would be nice, but that would have to be maintained. Just using the latest version is also fine for the scope of this document, IMHO