### PR TITLE
Removing second conflicting and confusing client_id entry from nats p…

### DIFF
--- a/reference/nats-protocol/nats-protocol/README.md
+++ b/reference/nats-protocol/nats-protocol/README.md
@@ -93,7 +93,6 @@ The valid options are as follows, encoded as JSON:
 | `git_commit`      | The git hash at which the NATS server was built.                                                                                                                       | string   | optional |
 | `jetstream`       | Whether the server supports JetStream.                                                                                                                                 | bool     | optional |
 | `ip`              | The IP of the server.                                                                                                                                                  | string   | optional |
-| `client_id`       | The ID of the client.                                                                                                                                                  | string   | optional |
 | `client_ip`       | The IP of the client.                                                                                                                                                  | string   | optional |
 | `nonce`           | The nonce for use in CONNECT.                                                                                                                                          | string   | optional |
 | `cluster`         | The name of the cluster.                                                                                                                                               | string   | optional |


### PR DESCRIPTION
…rotocol INFO table.

There were two entries which was confusing, I believe the first one is the correct one, here are the lines:

[Retained](https://github.com/nats-io/nats.docs/blob/master/reference/nats-protocol/nats-protocol/README.md?plain=1#L85)
```
| `client_id`       | The internal client identifier in the server. This can be used to filter client connections in monitoring, correlate with error logs, etc...                           | uint64   | optional |
```
and

[Removed](https://github.com/nats-io/nats.docs/blob/master/reference/nats-protocol/nats-protocol/README.md?plain=1#L96)
```
| `client_id`       | The ID of the client.                                                                                                                                                  | string   | optional |
```
🤗 