### PR TITLE
Fixing nex install organization name

### DIFF
--- a/nex/getting-started/installing.md
+++ b/nex/getting-started/installing.md
@@ -2,7 +2,7 @@
 All of the functionality you need for Nex is conveniently wrapped up in a single command line tool. To install it, all you need to do is use the following `go` command (A more formal release image will be added soon).
 
 ```
-go install github.com/ConnectEverything/nex/nex@latest
+go install github.com/synadia-io/nex/nex@latest
 ```
 
 {% hint style="info" %}


### PR DESCRIPTION
When following the nex cli install instructions you receive the following error:

```bash
root@nats-server:~# go install github.com/ConnectEverything/nex/nex@latest
go: downloading github.com/ConnectEverything/nex v0.0.0-20240122212631-fd8d975937bb
go: github.com/ConnectEverything/nex/nex@latest: version constraints conflict:
	github.com/ConnectEverything/nex@v0.0.0-20240122212631-fd8d975937bb: parsing go.mod:
	module declares its path as: github.com/synadia-io/nex
	        but was required as: github.com/ConnectEverything/nex
root@nats-server:~# go install github.com/synadia-io/nex/nex@latest
```

Updating the organization name appears to fix this issue:

```bash
root@nats-server:~# go install github.com/synadia-io/nex/nex@latest
go: downloading github.com/synadia-io/nex v0.0.0-20240122212631-fd8d975937bb
go: downloading github.com/cdfmlr/ellipsis v0.0.1
go: downloading github.com/choria-io/fisk v0.6.1
go: downloading github.com/jedib0t/go-pretty/v6 v6.4.9
go: downloading github.com/nats-io/jsm.go v0.1.1-0.20231031093634-09b45b142881
go: downloading github.com/nats-io/nats.go v1.31.0
go: downloading github.com/nats-io/nkeys v0.4.6
go: downloading github.com/sirupsen/logrus v1.9.3
go: downloading github.com/klauspost/compress v1.17.2
go: downloading golang.org/x/term v0.14.0
go: downloading golang.org/x/crypto v0.15.0
go: downloading golang.org/x/sys v0.14.0
go: downloading github.com/cloudevents/sdk-go v1.2.0
go: downloading github.com/google/uuid v1.4.0
go: downloading github.com/nats-io/jwt/v2 v2.5.3
go: downloading github.com/firecracker-microvm/firecracker-go-sdk v1.0.0
go: downloading github.com/nats-io/nats-server/v2 v2.10.5
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/rs/xid v1.5.0
go: downloading golang.org/x/net v0.17.0
go: downloading github.com/containerd/fifo v1.0.0
go: downloading github.com/containernetworking/cni v1.0.1
go: downloading github.com/containernetworking/plugins v1.0.1
go: downloading github.com/go-openapi/runtime v0.24.0
go: downloading github.com/go-openapi/strfmt v0.21.2
go: downloading github.com/hashicorp/go-multierror v1.1.1
go: downloading github.com/go-openapi/errors v0.20.2
go: downloading github.com/go-openapi/swag v0.21.1
go: downloading github.com/go-openapi/validate v0.22.0
go: downloading go.opencensus.io v0.22.3
go: downloading go.uber.org/zap v1.10.0
go: downloading golang.org/x/time v0.4.0
go: downloading github.com/opentracing/opentracing-go v1.2.0
go: downloading github.com/hashicorp/errwrap v1.0.0
go: downloading github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
go: downloading github.com/mitchellh/mapstructure v1.5.0
go: downloading github.com/oklog/ulid v1.3.1
go: downloading go.mongodb.org/mongo-driver v1.8.3
go: downloading github.com/mailru/easyjson v0.7.7
go: downloading github.com/go-openapi/analysis v0.21.2
go: downloading github.com/go-openapi/jsonpointer v0.19.5
go: downloading github.com/go-openapi/loads v0.21.1
go: downloading github.com/go-openapi/spec v0.20.4
go: downloading github.com/lightstep/tracecontext.go v0.0.0-20181129014701-1757c391b1ac
go: downloading github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
go: downloading github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
go: downloading go.uber.org/atomic v1.4.0
go: downloading go.uber.org/multierr v1.1.0
go: downloading github.com/josharian/intern v1.0.0
go: downloading github.com/go-openapi/jsonreference v0.19.6
go: downloading github.com/go-stack/stack v1.8.1
go: downloading github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f
go: downloading github.com/PuerkitoBio/purell v1.1.1
go: downloading golang.org/x/text v0.14.0
go: downloading github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
root@nats-server:~# nex --version
vdevelopment [] | Built-on:
```