### PR TITLE
Remove colon from the unique_tags value

### DIFF
--- a/nats-concepts/jetstream/streams.md
+++ b/nats-concepts/jetstream/streams.md
@@ -125,21 +125,21 @@ For example, a server A, B, and C in the above cluster might all the same config
 server_tags: ["cloud:aws", "region:us-east1", "az:a"]
 
 jetstream: {
-  unique_tag: "az:"
+  unique_tag: "az"
 }
 
 // Server B
 server_tags: ["cloud:aws", "region:us-east1", "az:b"]
 
 jetstream: {
-  unique_tag: "az:"
+  unique_tag: "az"
 }
 
 // Server C
 server_tags: ["cloud:aws", "region:us-east1", "az:c"]
 
 jetstream: {
-  unique_tag: "az:"
+  unique_tag: "az"
 }
 ```
 

--- a/running-a-nats-service/nats_admin/monitoring/readme.md
+++ b/running-a-nats-service/nats_admin/monitoring/readme.md
@@ -716,7 +716,7 @@ You can also report detailed consumer information on a per connection basis usin
     "max_memory": 10485760,
     "max_storage": 10485760,
     "store_dir": "/var/folders/9h/6g_c9l6n6bb8gp331d_9y0_w0000gn/T/srv_7500251552558",
-    "unique_tag": "az:"
+    "unique_tag": "az"
   },
   "memory": 0,
   "storage": 66,


### PR DESCRIPTION
Before this change, the value of the `unique_tag` was in the format of `az:` instead of `az`. The colon causes the unique tag to not function correctly. This change removes the colon and aligns the value with the tests in `nats-server`.