### PR TITLE
Remove the asci constraints on subject and subject tokens

### DIFF
--- a/reference/nats-protocol/nats-protocol/README.md
+++ b/reference/nats-protocol/nats-protocol/README.md
@@ -16,15 +16,15 @@ The NATS server implements a [zero allocation byte parser](https://youtu.be/ylRK
 
 **Newlines**: NATS uses `␍` followed by `␊` (`␍␊`, `0x0D0A`) to terminate protocol messages. This newline sequence is also used to mark the end of the message payload in `PUB`, `MSG`, `HPUB`, and `HMSG` protocol messages.
 
-**Subject names**: Subject names, including reply subject names, are case-sensitive and must be non-empty alphanumeric strings with no embedded whitespace. All ascii alphanumeric characters except spaces/tabs and separators which are `.` and `>` are allowed. Subject names can be optionally token-delimited using the dot character (`.`), e.g.:
+**Subject names**: Subject names, including reply subject names, are case-sensitive and must be non-empty alphanumeric strings with no embedded whitespace. All UTF-8 characters except spaces/tabs and separators which are `.` and `>` are allowed. Subject names can be optionally token-delimited using the dot character (`.`), e.g.:
 
 `FOO`, `BAR`, `foo.bar`, `foo.BAR`, `FOO.BAR` and `FOO.BAR.BAZ` are all valid subject names
 
 `FOO. BAR`, `foo. .bar` and`foo..bar` are _not_ valid subject names
 
-A subject is comprised of 1 or more tokens. Tokens are separated by `.` and can be any non space ascii alphanumeric character. The full wildcard token `>` is only valid as the last token and matches all tokens past that point. A token wildcard, `*` matches any token in the position it was listed. Wildcard tokens should only be used in a wildcard capacity and not part of a literal token.
+A subject is comprised of 1 or more tokens. Tokens are separated by `.` and can be any non whitespace UTF-8 character. The full wildcard token `>` is only valid as the last token and matches all tokens past that point. A token wildcard, `*` matches any token in the position it was listed. Wildcard tokens should only be used in a wildcard capacity and not part of a literal token.
 
-**Character Encoding**: Subject names should be ascii characters for maximum interoperability. Due to language constraints and performance, some clients may support UTF-8 subject names, as may the server. No guarantees of non-ASCII support are provided.
+**Character Encoding**: Subject names should be UTF-8 compatible.
 
 **Wildcards**: NATS supports the use of wildcards in subject subscriptions.
 


### PR DESCRIPTION
We agreed that we no longer have to constraint subjects to ASCI characters, as all clients and server support UTF-8.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>