### PR TITLE
Fix jetstream docs on mirrors vs sources 

### DIFF
--- a/nats-concepts/jetstream/streams.md
+++ b/nats-concepts/jetstream/streams.md
@@ -170,7 +170,7 @@ When a stream is configured as a `source` or `mirror`, it will automatically and
 A source or mirror stream can have its own retention policy, replication, and storage type. Changes to to the source or mirror,e.g. deleting messages or publishing, do not reflect on the origin stream.
 
 {% hint style="info" %}
-`Sources` is a generalization of the `Mirror` and allows for sourcing data from one or more streams concurrently. We suggest to use `Sources` in new configurations. 
+`Sources` is a generalization of the `Mirror` and allows for sourcing data from one or more streams concurrently. 
 If you require the target stream to act as a read-only replica:
 * Configure the stream without listen subjects **or**
 * Temporarily disable the listen subjects through client authorizations. 


### PR DESCRIPTION
This sentence made me think mirrors are somehow getting deprecated. Removed it to avoid confusion 

see slack conversation https://natsio.slack.com/archives/CM3T6T7JQ/p1719506018534819