### PR TITLE
JetStream on Leaf Nodes - fixed wrong duplicated subject section in stream source example

### DIFF
--- a/running-a-nats-service/configuration/leafnodes/jetstream_leafnodes.md
+++ b/running-a-nats-service/configuration/leafnodes/jetstream_leafnodes.md
@@ -429,7 +429,7 @@ system_account: SYS
 
 #### Copying via `source` and `mirror`
 
-Once the servers have been restarted or reloaded, a `mirror` can be created as follows \(same applies to `source`\): On import from a different account the renamed prefix `JS.acc@hub.API` is provided. In addition, the delivery subject name is extended to also include the importing domain and stream. This makes it unique to that particular import. If every delivery prefix follows the pattern `<static type>.<exporting account>.<exporting domain>.<importing account>.<importing domain>.<importing domain>.<importing stream name>` overlaps caused by multiple imports are avoided.
+Once the servers have been restarted or reloaded, a `mirror` can be created as follows \(same applies to `source`\): On import from a different account the renamed prefix `JS.acc@hub.API` is provided. In addition, the delivery subject name is extended to also include the importing domain and stream. This makes it unique to that particular import. If every delivery prefix follows the pattern `<static type>.<exporting account>.<exporting domain>.<importing account>.<importing domain>.<importing stream name>` overlaps caused by multiple imports are avoided.
 
 ```bash
 nats  --server nats://import_mirror:import_mirror@localhost:4222 stream add --js-domain hub --mirror aggregate-test-leaf


### PR DESCRIPTION
In the doc section related to copy a stream from a different account and JS domain, an example is provided to build a subject with a unique pattern. 
The PR fix a typo in the example that duplicates the `importing domain` section of the subject.