### PR TITLE
Very minor Typo fix - need to needs

### DIFF
--- a/running-a-nats-service/configuration/leafnodes/leafnode_conf.md
+++ b/running-a-nats-service/configuration/leafnodes/leafnode_conf.md
@@ -102,7 +102,7 @@ leafnodes {
 }
 ```
 
-With above configuration, if a soliciting server creates a Leafnode connection with url: `nats://leaf:secret@host:port`, then the accepting server will bind the leafnode connection to the account "TheAccount". This account need to exist otherwise the connection will be rejected.
+With above configuration, if a soliciting server creates a Leafnode connection with url: `nats://leaf:secret@host:port`, then the accepting server will bind the leafnode connection to the account "TheAccount". This account needs to exist otherwise the connection will be rejected.
 
 Multi-users mode:
 


### PR DESCRIPTION
Just fixing a minor typo. The account "need" to "needs"

![image](https://github.com/user-attachments/assets/91ce8266-255f-4263-b5bd-3e154194aa0e)
