### PR TITLE
Fix broken link to jetstream entrypoint

### DIFF
--- a/nats-concepts/core-nats/queue-groups/queue.md
+++ b/nats-concepts/core-nats/queue-groups/queue.md
@@ -24,7 +24,7 @@ When a request is made to a service (request/reply) and the NATS Server knows th
 
 ## Stream as a queue
 
-With [JetStream](../../jetstream/) a stream can also be used as a queue by setting the retention policy to `WorkQueuePolicy` and leveraging [`pull` consumers](../../jetstream/consumers.md) to get easy horizontal scalability of the processing (or using an explicit ack push consumer with a queue group of subscribers).
+With [JetStream](../../jetstream/readme.md) a stream can also be used as a queue by setting the retention policy to `WorkQueuePolicy` and leveraging [`pull` consumers](../../jetstream/consumers.md) to get easy horizontal scalability of the processing (or using an explicit ack push consumer with a queue group of subscribers).
 
 ![](../../../.gitbook/assets/queue.svg)
 


### PR DESCRIPTION
By default it seems to want to go to https://github.com/nats-io/nats.docs/blob/master/nats-concepts/jetstream/README.md, which 404s.