### PR TITLE
Remove internal only subjects

### DIFF
--- a/running-a-nats-service/configuration/sys_accounts/README.md
+++ b/running-a-nats-service/configuration/sys_accounts/README.md
@@ -30,8 +30,6 @@ Server initiated events:
 * `$SYS.ACCOUNT.<id>.DISCONNECT` (client disconnects)
 * `$SYS.ACCOUNT.<id>.SERVER.CONNS` (connections for an account changed)
 * `$SYS.SERVER.<id>.CLIENT.AUTH.ERR` (authentication error)
-* `$SYS.ACCOUNT.<id>.LEAFNODE.CONNECT` (leaf node connects)
-* `$SYS.ACCOUNT.<id>.LEAFNODE.DISCONNECT` (leaf node disconnects)
 * `$SYS.SERVER.<id>.STATSZ` (stats summary)
 
 In addition other tools with system account privileges, can initiate requests (Examples can be found [here](sys\_accounts.md#system-services)):


### PR DESCRIPTION
  `$SYS.ACCOUNT.<id>.LEAFNODE.CONNECT` is marked as internal only [^1]
  `$SYS.ACCOUNT.<id>.LEAFNODE.DISCONNECT` doesn't exist

[^1]: https://github.com/nats-io/nats-server/blob/e68ac05b18eee0e2d919e47205c14b6c3072de95/server/events.go#L70