### PR TITLE
Add link to nats cli installation insturctions

### DIFF
--- a/running-a-nats-service/configuration/jetstream-config/configuration_mgmt/nats-admin-cli.md
+++ b/running-a-nats-service/configuration/jetstream-config/configuration_mgmt/nats-admin-cli.md
@@ -2,7 +2,7 @@
 
 ## nats Admin CLI
 
-The `nats` CLI can be used to manage Streams and Consumers easily using it's `--config` flag, for example:
+The [`nats` CLI](https://github.com/nats-io/natscli?tab=readme-ov-file#installation) can be used to manage Streams and Consumers easily using it's `--config` flag, for example:
 
 ## Add a new Stream
 


### PR DESCRIPTION
It is not mentioned anywhere in this doc how to install the cli. So add link to it.