### PR TITLE
Replace duplicated nats-cli installation instructions with link to natscli repo

### DIFF
--- a/nats-concepts/what-is-nats/walkthrough_setup.md
+++ b/nats-concepts/what-is-nats/walkthrough_setup.md
@@ -8,21 +8,7 @@ We have provided Walkthroughs for you to try NATS (and JetStream) on your own. I
 
 ## Installing the [`nats`](../../using-nats/nats-tools/nats\_cli/) CLI Tool
 
-For MacOS:
-
-```shell
-brew tap nats-io/nats-tools
-brew install nats-io/nats-tools/nats
-```
-
-For Arch Linux:
-
-```shell
-yay natscli
-```
-
-For other versions of Linux and for Windows:\
-The `.deb` or `.rpm` files and Windows binaries (even for ARM) are available here [GitHub Releases](https://github.com/nats-io/natscli/releases).
+Please refer to the [installation section in the readme](https://github.com/nats-io/natscli?tab=readme-ov-file#installation).
 
 ## Installing the NATS server locally (if needed)
 

--- a/running-a-nats-service/clients.md
+++ b/running-a-nats-service/clients.md
@@ -16,27 +16,8 @@ If your application is in Go, and if it fits your use case and deployment scenar
 
 ## Installing the `nats` CLI Tool
 
-From the shell (all platforms), to get the binary for the latest (top of the `main` branch) version of `nats` you can simply do:
-```shell
-curl -sf https://binaries.nats.dev/nats-io/natscli/nats | sh
-```
+Please refer to the [installation section in the readme](https://github.com/nats-io/natscli?tab=readme-ov-file#installation).
 
-You can also get a specific version by adding `@` followed by the version's tag, e.g. `curl -sf https://binaries.nats.dev/nats-io/natscli/nats@v0.1.4 | sh`
-
-For macOS:
-
-```shell
-brew tap nats-io/nats-tools
-brew install nats-io/nats-tools/nats
-```
-
-For Arch Linux:
-
-```shell
-yay natscli
-```
-
-Binaries are also available as [GitHub Releases](https://github.com/nats-io/natscli/releases).
 
 ## Testing your setup
 

--- a/running-a-nats-service/nats_admin/jetstream_admin/README.md
+++ b/running-a-nats-service/nats_admin/jetstream_admin/README.md
@@ -1,10 +1,9 @@
 # Administration & Usage from CLI
 
-Once the server is running it's time to use the management tool. This can be downloaded from the [GitHub Release Page](https://github.com/nats-io/natscli/releases/). On OS X homebrew can be used to install the latest version:
+Once the server is running it's time to use the management tool.  
+Please refer to the [installation section in the readme](https://github.com/nats-io/natscli?tab=readme-ov-file#installation).
 
-```shell
-brew tap nats-io/nats-tools
-brew install nats-io/nats-tools/nats
+```
 nats --help
 nats cheat
 ```


### PR DESCRIPTION
The readme has more comprehensive instructions, and more likely to stay up to date