### PR TITLE
Fix broken links in monitoring page

### DIFF
--- a/running-a-nats-service/nats_admin/monitoring/readme.md
+++ b/running-a-nats-service/nats_admin/monitoring/readme.md
@@ -7,10 +7,10 @@ To monitor the NATS messaging system, `nats-server` provides a lightweight HTTP 
 * [General Server Information](#general-information)
 * [Connections](#connection-information)
 * [Routing](#route-information)
-* [Leaf Nodes](#leaf-nodes-information)
+* [Leaf Nodes](#leaf-node-information)
 * [Subscription Routing](#subscription-routing-information)
 * [Account Information](#account-information)
-* [Account Stats](#account-stats)
+* [Account Stats](#account-statistics)
 * [JetStream Information](#jetstream-information)
 * [Health](#health)
 

--- a/running-a-nats-service/nats_admin/monitoring/readme.md
+++ b/running-a-nats-service/nats_admin/monitoring/readme.md
@@ -6,13 +6,13 @@ To monitor the NATS messaging system, `nats-server` provides a lightweight HTTP 
 
 * [General Server Information](#general-information)
 * [Connections](#connection-information)
-* [Routing](./#route-information)
-* [Leaf Nodes](./#leaf-nodes-information)
-* [Subscription Routing](./#subscription-routing-information)
-* [Account Information](./#account-information)
-* [Account Stats](./#account-stats)
-* [JetStream Information](./#jetstream-information)
-* [Health](./#health)
+* [Routing](#route-information)
+* [Leaf Nodes](#leaf-nodes-information)
+* [Subscription Routing](#subscription-routing-information)
+* [Account Information](#account-information)
+* [Account Stats](#account-stats)
+* [JetStream Information](#jetstream-information)
+* [Health](#health)
 
 All endpoints return a JSON object.
 

--- a/running-a-nats-service/nats_admin/monitoring/readme.md
+++ b/running-a-nats-service/nats_admin/monitoring/readme.md
@@ -4,8 +4,8 @@
 
 To monitor the NATS messaging system, `nats-server` provides a lightweight HTTP server on a dedicated monitoring port. The monitoring server provides several endpoints, providing statistics and other information about the following:
 
-* [General Server Information](./#general-information)
-* [Connections](./#connection-information)
+* [General Server Information](#general-information)
+* [Connections](#connection-information)
 * [Routing](./#route-information)
 * [Leaf Nodes](./#leaf-nodes-information)
 * [Subscription Routing](./#subscription-routing-information)


### PR DESCRIPTION
Fixed the list of links at the top of the https://docs.nats.io/running-a-nats-service/nats_admin/monitoring page:
![image](https://github.com/user-attachments/assets/9eb622f0-77fb-4906-9634-84fb98357e12)
