### PR TITLE
Update installation.md: use scoop on windows

### DIFF
--- a/running-a-nats-service/installation.md
+++ b/running-a-nats-service/installation.md
@@ -103,10 +103,10 @@ More information on [containerized NATS is available here](running/nats_docker/)
 
 ## Installing via a Package Manager
 
-On Windows:
+On Windows, using [scoop.sh](https://scoop.sh):
 
 ```shell
-choco install nats-server
+scoop install main/nats-server
 ```
 
 On Mac OS:


### PR DESCRIPTION
Fixes: https://github.com/nats-io/nats.docs/issues/586  (partially)

Scoop installation was added in https://github.com/nats-io/nats-server/issues/2063

Chocolatey package has not been updated since 2019...