### PR TITLE
Upd headers to include endpoint name, so it is easier to navigate

### DIFF
--- a/running-a-nats-service/nats_admin/monitoring/readme.md
+++ b/running-a-nats-service/nats_admin/monitoring/readme.md
@@ -5,15 +5,15 @@
 To monitor the NATS messaging system, `nats-server` provides a lightweight HTTP server on a dedicated monitoring port. The monitoring server provides several endpoints, providing statistics and other information about the following:
 
 * [General Server Information `(/varz)`](#general-information-varz)
-* [Connections](#connection-information-connz)
-* [Routing](#route-information-routez)
-* [Gateway](#gateway-information-gatewayz)
-* [Leaf Nodes](#leaf-node-information-leafz)
-* [Subscription Routing](#subscription-routing-information-subsz)
-* [Account Information](#account-information-accountz)
-* [Account Stats](#account-statistics-accstatz)
-* [JetStream Information](#jetstream-information-jsz)
-* [Health](#health-healthz)
+* [Connections (`/connz`)](#connection-information-connz)
+* [Routing (`/routez`)](#route-information-routez)
+* [Gateway (`/gatewayz`)](#gateway-information-gatewayz)
+* [Leaf Nodes (`/leafz`)](#leaf-node-information-leafz)
+* [Subscription Routing (`/subsz`)](#subscription-routing-information-subsz)
+* [Account Information (`/accountz`)](#account-information-accountz)
+* [Account Stats (`/accstatz`)](#account-statistics-accstatz)
+* [JetStream Information (`/jsz`)](#jetstream-information-jsz)
+* [Health (`/healthz`)](#health-healthz)
 
 All endpoints return a JSON object.
 

--- a/running-a-nats-service/nats_admin/monitoring/readme.md
+++ b/running-a-nats-service/nats_admin/monitoring/readme.md
@@ -4,7 +4,7 @@
 
 To monitor the NATS messaging system, `nats-server` provides a lightweight HTTP server on a dedicated monitoring port. The monitoring server provides several endpoints, providing statistics and other information about the following:
 
-* [General Server Information](#general-information-varz)
+* [General Server Information `(/varz)`](#general-information-varz)
 * [Connections](#connection-information-connz)
 * [Routing](#route-information-routez)
 * [Gateway](#gateway-information-gatewayz)

--- a/running-a-nats-service/nats_admin/monitoring/readme.md
+++ b/running-a-nats-service/nats_admin/monitoring/readme.md
@@ -4,15 +4,16 @@
 
 To monitor the NATS messaging system, `nats-server` provides a lightweight HTTP server on a dedicated monitoring port. The monitoring server provides several endpoints, providing statistics and other information about the following:
 
-* [General Server Information](#general-information)
-* [Connections](#connection-information)
-* [Routing](#route-information)
-* [Leaf Nodes](#leaf-node-information)
-* [Subscription Routing](#subscription-routing-information)
-* [Account Information](#account-information)
-* [Account Stats](#account-statistics)
-* [JetStream Information](#jetstream-information)
-* [Health](#health)
+* [General Server Information](#general-information-varz)
+* [Connections](#connection-information-connz)
+* [Routing](#route-information-routez)
+* [Gateway](#gateway-information-gatewayz)
+* [Leaf Nodes](#leaf-node-information-leafz)
+* [Subscription Routing](#subscription-routing-information-subsz)
+* [Account Information](#account-information-accountz)
+* [Account Stats](#account-statistics-accstatz)
+* [JetStream Information](#jetstream-information-jsz)
+* [Health](#health-healthz)
 
 All endpoints return a JSON object.
 

--- a/running-a-nats-service/nats_admin/monitoring/readme.md
+++ b/running-a-nats-service/nats_admin/monitoring/readme.md
@@ -4,7 +4,7 @@
 
 To monitor the NATS messaging system, `nats-server` provides a lightweight HTTP server on a dedicated monitoring port. The monitoring server provides several endpoints, providing statistics and other information about the following:
 
-* [General Server Information `(/varz)`](#general-information-varz)
+* [General Server Information (`/varz`)](#general-information-varz)
 * [Connections (`/connz`)](#connection-information-connz)
 * [Routing (`/routez`)](#route-information-routez)
 * [Gateway (`/gatewayz`)](#gateway-information-gatewayz)

--- a/running-a-nats-service/nats_admin/monitoring/readme.md
+++ b/running-a-nats-service/nats_admin/monitoring/readme.md
@@ -63,6 +63,7 @@ N/A
 #### Response
 
 <details>
+<summary>Full JSON schema</summary>
 
 ```json
 {

--- a/running-a-nats-service/nats_admin/monitoring/readme.md
+++ b/running-a-nats-service/nats_admin/monitoring/readme.md
@@ -38,11 +38,11 @@ As a command-line option:
 nats-server -m 8222
 ```
 
-Once the server is running using one of the two methods, go to http://localhost:8222 to browse the available endpoints detailed below.
+Once the server is running using one of the two methods, go to <http://localhost:8222> to browse the available endpoints detailed below.
 
 ## Monitoring Endpoints
 
-### General Information
+### General Information `(/varz)`
 
 The `/varz` endpoint returns general information about the server state and configuration.
 
@@ -60,6 +60,8 @@ N/A
 [https://demo.nats.io:8222/varz](https://demo.nats.io:8222/varz)
 
 #### Response
+
+<details>
 
 ```json
 {
@@ -120,7 +122,9 @@ N/A
 }
 ```
 
-### Connection Information
+</details>
+
+### Connection Information (`/connz`)
 
 The `/connz` endpoint reports more detailed information on current and recently closed connections. It uses a paging mechanism which defaults to 1024 connections.
 
@@ -174,6 +178,8 @@ Get closed connection information: [https://demo.nats.io:8222/connz?state=closed
 You can also report detailed subscription information on a per connection basis using subs=1. For example: [https://demo.nats.io:8222/connz?limit=1\&offset=1\&subs=1](https://demo.nats.io:8222/connz?limit=1\&offset=1\&subs=1).
 
 #### Response
+
+<details>
 
 ```json
 {
@@ -249,7 +255,9 @@ You can also report detailed subscription information on a per connection basis 
 }
 ```
 
-### Route Information
+</details>
+
+### Route Information  (`/routez`)
 
 The `/routez` endpoint reports information on active routes for a cluster. Routes are expected to be low, so there is no paging mechanism with this endpoint.
 
@@ -271,6 +279,8 @@ As noted above, the `routez` endpoint does support the `subs` argument from the 
 * Get route information: [https://demo.nats.io:8222/routez?subs=1](https://demo.nats.io:8222/routez?subs=1)
 
 #### Response
+
+<details>
 
 ```json
 {
@@ -295,7 +305,9 @@ As noted above, the `routez` endpoint does support the `subs` argument from the 
 }
 ```
 
-### Gateway Information
+</details>
+
+### Gateway Information (`/gatewayz`)
 
 The `/gatewayz` endpoint reports information about gateways used to create a NATS supercluster. Like routes, the number of gateways are expected to be low, so there is no paging mechanism with this endpoint.
 
@@ -317,6 +329,8 @@ The `/gatewayz` endpoint reports information about gateways used to create a NAT
 * Retrieve Gateway Information: [https://demo.nats.io:8222/gatewayz](https://demo.nats.io:8222/gatewayz)
 
 #### Response
+
+<details>
 
 ```json
 {
@@ -431,7 +445,9 @@ The `/gatewayz` endpoint reports information about gateways used to create a NAT
 }
 ```
 
-### Leaf Node Information
+</details>
+
+### Leaf Node Information (`/leafz`)
 
 The `/leafz` endpoint reports detailed information about the leaf node connections.
 
@@ -453,6 +469,8 @@ As noted above, the `leafz` endpoint does support the `subs` argument from the `
 * Get leaf nodes information: [https://demo.nats.io:8222/leafz?subs=1](https://demo.nats.io:8222/leafz?subs=1)
 
 #### Response
+
+<details>
 
 ```json
 {
@@ -476,7 +494,9 @@ As noted above, the `leafz` endpoint does support the `subs` argument from the `
 }
 ```
 
-### Subscription Routing Information
+</details>
+
+### Subscription Routing Information (`/subsz`)
 
 The `/subsz` endpoint reports detailed information about the current subscriptions and the routing data structure. It is not normally used.
 
@@ -500,6 +520,8 @@ The `/subsz` endpoint reports detailed information about the current subscriptio
 
 #### Response
 
+<details>
+
 ```json
 {
   "num_subscriptions": 2,
@@ -513,7 +535,9 @@ The `/subsz` endpoint reports detailed information about the current subscriptio
 }
 ```
 
-### Account Information
+</details>
+
+### Account Information (`/accountz`)
 
 The `/accountz` endpoint reports information on a server's active accounts. The default behavior is to return a list of all accounts known to the server.
 
@@ -545,6 +569,8 @@ Default behavior:
 ```
 
 Retrieve specific account:
+
+<details>
 
 ```json
 {
@@ -610,7 +636,9 @@ Retrieve specific account:
 }
 ```
 
-### Account Statistics
+</details>
+
+### Account Statistics (`/accstatz`)
 
 The `/accstatz` endpoint reports per-account statistics such as the number of connections, messages/bytes in/out, etc.
 
@@ -627,10 +655,12 @@ The `/accstatz` endpoint reports per-account statistics such as the number of co
 
 #### Examples
 
-* Accounts with active connections - https://demo.nats.io:8222/accstatz
-* Include ones without any connections (in this case `$SYS`)- https://demo.nats.io:8222/accstatz?unused=1
+* Accounts with active connections - <https://demo.nats.io:8222/accstatz>
+* Include ones without any connections (in this case `$SYS`)- <https://demo.nats.io:8222/accstatz?unused=1>
 
 #### Response
+
+<details>
 
 ```json
 {
@@ -673,7 +703,9 @@ The `/accstatz` endpoint reports per-account statistics such as the number of co
 }
 ```
 
-### JetStream Information
+</details>
+
+### JetStream Information (`/jsz`)
 
 The `/jsz` endpoint reports more detailed information on JetStream. For accounts, it uses a paging mechanism that defaults to 1024 connections.
 
@@ -707,6 +739,8 @@ Request accounts and control limit and offset: [https://demo.nats.io:8222/jsz?ac
 You can also report detailed consumer information on a per connection basis using consumer=true. For example: [https://demo.nats.io:8222/jsz?consumers=true](https://demo.nats.io:8222/jsz?consumers=true).
 
 #### Response
+
+<details>
 
 ```json
 {
@@ -816,7 +850,9 @@ You can also report detailed consumer information on a per connection basis usin
 }
 ```
 
-### Health
+</details>
+
+### Health (`/healthz`)
 
 The `/healthz` endpoint returns OK if the server is able to accept connections.
 
@@ -835,8 +871,8 @@ The `/healthz` endpoint returns OK if the server is able to accept connections.
 
 #### Example
 
-* Default - https://demo.nats.io:8222/healthz
-* Expect JetStream - https://demo.nats.io:8222/healthz?js-enabled-only=true
+* Default - <https://demo.nats.io:8222/healthz>
+* Expect JetStream - <https://demo.nats.io:8222/healthz?js-enabled-only=true>
 
 #### Response
 

--- a/running-a-nats-service/nats_admin/monitoring/readme.md
+++ b/running-a-nats-service/nats_admin/monitoring/readme.md
@@ -62,9 +62,6 @@ N/A
 
 #### Response
 
-<details>
-<summary>Full JSON schema</summary>
-
 ```json
 {
   "server_id": "NACDVKFBUW4C4XA24OOT6L4MDP56MW76J5RJDFXG7HLABSB46DCMWCOW",
@@ -124,8 +121,6 @@ N/A
 }
 ```
 
-</details>
-
 ### Connection Information (`/connz`)
 
 The `/connz` endpoint reports more detailed information on current and recently closed connections. It uses a paging mechanism which defaults to 1024 connections.
@@ -180,8 +175,6 @@ Get closed connection information: [https://demo.nats.io:8222/connz?state=closed
 You can also report detailed subscription information on a per connection basis using subs=1. For example: [https://demo.nats.io:8222/connz?limit=1\&offset=1\&subs=1](https://demo.nats.io:8222/connz?limit=1\&offset=1\&subs=1).
 
 #### Response
-
-<details>
 
 ```json
 {
@@ -257,8 +250,6 @@ You can also report detailed subscription information on a per connection basis 
 }
 ```
 
-</details>
-
 ### Route Information  (`/routez`)
 
 The `/routez` endpoint reports information on active routes for a cluster. Routes are expected to be low, so there is no paging mechanism with this endpoint.
@@ -281,8 +272,6 @@ As noted above, the `routez` endpoint does support the `subs` argument from the 
 * Get route information: [https://demo.nats.io:8222/routez?subs=1](https://demo.nats.io:8222/routez?subs=1)
 
 #### Response
-
-<details>
 
 ```json
 {
@@ -307,8 +296,6 @@ As noted above, the `routez` endpoint does support the `subs` argument from the 
 }
 ```
 
-</details>
-
 ### Gateway Information (`/gatewayz`)
 
 The `/gatewayz` endpoint reports information about gateways used to create a NATS supercluster. Like routes, the number of gateways are expected to be low, so there is no paging mechanism with this endpoint.
@@ -331,8 +318,6 @@ The `/gatewayz` endpoint reports information about gateways used to create a NAT
 * Retrieve Gateway Information: [https://demo.nats.io:8222/gatewayz](https://demo.nats.io:8222/gatewayz)
 
 #### Response
-
-<details>
 
 ```json
 {
@@ -447,8 +432,6 @@ The `/gatewayz` endpoint reports information about gateways used to create a NAT
 }
 ```
 
-</details>
-
 ### Leaf Node Information (`/leafz`)
 
 The `/leafz` endpoint reports detailed information about the leaf node connections.
@@ -472,8 +455,6 @@ As noted above, the `leafz` endpoint does support the `subs` argument from the `
 
 #### Response
 
-<details>
-
 ```json
 {
   "server_id": "NC2FJCRMPBE5RI5OSRN7TKUCWQONCKNXHKJXCJIDVSAZ6727M7MQFVT3",
@@ -495,8 +476,6 @@ As noted above, the `leafz` endpoint does support the `subs` argument from the `
   ]
 }
 ```
-
-</details>
 
 ### Subscription Routing Information (`/subsz`)
 
@@ -522,8 +501,6 @@ The `/subsz` endpoint reports detailed information about the current subscriptio
 
 #### Response
 
-<details>
-
 ```json
 {
   "num_subscriptions": 2,
@@ -536,8 +513,6 @@ The `/subsz` endpoint reports detailed information about the current subscriptio
   "avg_fanout": 0
 }
 ```
-
-</details>
 
 ### Account Information (`/accountz`)
 
@@ -571,8 +546,6 @@ Default behavior:
 ```
 
 Retrieve specific account:
-
-<details>
 
 ```json
 {
@@ -638,8 +611,6 @@ Retrieve specific account:
 }
 ```
 
-</details>
-
 ### Account Statistics (`/accstatz`)
 
 The `/accstatz` endpoint reports per-account statistics such as the number of connections, messages/bytes in/out, etc.
@@ -661,8 +632,6 @@ The `/accstatz` endpoint reports per-account statistics such as the number of co
 * Include ones without any connections (in this case `$SYS`)- <https://demo.nats.io:8222/accstatz?unused=1>
 
 #### Response
-
-<details>
 
 ```json
 {
@@ -705,8 +674,6 @@ The `/accstatz` endpoint reports per-account statistics such as the number of co
 }
 ```
 
-</details>
-
 ### JetStream Information (`/jsz`)
 
 The `/jsz` endpoint reports more detailed information on JetStream. For accounts, it uses a paging mechanism that defaults to 1024 connections.
@@ -741,8 +708,6 @@ Request accounts and control limit and offset: [https://demo.nats.io:8222/jsz?ac
 You can also report detailed consumer information on a per connection basis using consumer=true. For example: [https://demo.nats.io:8222/jsz?consumers=true](https://demo.nats.io:8222/jsz?consumers=true).
 
 #### Response
-
-<details>
 
 ```json
 {
@@ -851,8 +816,6 @@ You can also report detailed consumer information on a per connection basis usin
   ]
 }
 ```
-
-</details>
 
 ### Health (`/healthz`)
 


### PR DESCRIPTION
People refer to those enpoints by their address, e.g. "Check out `/varz`", so let's include it in the headers