### PR TITLE
Fix streams C example code block

### DIFF
--- a/using-nats/developing-with-nats/js/streams.md
+++ b/using-nats/developing-with-nats/js/streams.md
@@ -258,7 +258,7 @@ await js.DeleteStreamAsync("example-stream");
 {% endtab %}
 
 {% tab title="C" %}
-````
+```C
 #include "examples.h"
 
 static const char *usage = ""\
@@ -448,14 +448,5 @@ int main(int argc, char **argv)
     return 0;
 }
 ```
-
-</div>
-
-</div>
-
-</div>
-
-</div>
-````
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
I unfortunately can't build the Gitbook right now (probably some `npm` weirdness with the instructions) so I can't be 100% sure this is correct, but I think it is. Right now before this change this is what the end of the code block looks like:

<img width="753" alt="Screenshot 2025-01-10 at 10 52 50 AM" src="https://github.com/user-attachments/assets/0d68b1b0-b4c8-40d5-ad5d-af1bb5bd0131" />

https://docs.nats.io/using-nats/developer/develop_jetstream/streams
