### PR TITLE
Improve authentication timeout documentation

### DIFF
--- a/running-a-nats-service/configuration/securing_nats/auth_intro/auth_timeout.md
+++ b/running-a-nats-service/configuration/securing_nats/auth_intro/auth_timeout.md
@@ -1,10 +1,17 @@
 # Authentication Timeout
 
-Much like the [`tls timeout` option](/running-a-nats-service/configuration/securing_nats/tls.md#tls-timeout), authentication can specify a `timeout` value.
+You can specify a timeout to limit how long the server will wait for a client to authenticate.
+
+If you don't specify a value, or if you specify the value "0", then the default will be 1 second more than the `tls_timeout`.
+
+If you do specify an invalid value, it will use a default of 1 second.
 
 If a client doesn't authenticate to the server within the specified time, the server disconnects the server to prevent abuses.
 
 Timeouts are specified in seconds (and can be fractional).
+Unlike `tls_timeout`, you cannot use "human readable" values like `10s`, you
+must specify a number, which will be interpreted as seconds.
+`10` will be 10 seconds, `3.5` will be 3 seconds and 500 milliseconds, etc.
 
 As with TLS timeouts, long timeouts can be an opportunity for abuse. If setting the authentication timeout, it is important to note that it should be longer than the `tls timeout` option, as the authentication timeout includes the TLS upgrade time.
 


### PR DESCRIPTION
Previously, referencing the tls_timeout setting, the docs implied that human readable strings would work, like '10s'

Using a value that could not be parsed as an int64 or float64, would simply default back to 1 second