### PR TITLE
NATS admin signals.md: document command -> signal mapping

### DIFF
--- a/running-a-nats-service/nats_admin/signals.md
+++ b/running-a-nats-service/nats_admin/signals.md
@@ -14,7 +14,16 @@ On Unix systems, the NATS server responds to the following signals:
 | `SIGHUP`  | Reloads server configuration file                              |
 | `SIGUSR2` | Stops the server after evicting all clients \(lame duck mode\) |
 
-The `nats-server` binary can be used to send these signals to running NATS servers using the `-sl` flag:
+The `nats-server` binary can be used to send these signals to running NATS servers using the `--signal`/`-sl` flag. It supports the following commands:
+
+| Command  | Signal    |
+| :------- | :-------- |
+| `stop`   | `SIGKILL` |
+| `quit`   | `SIGINT`  |
+| `term`   | `SIGTERM` |
+| `reopen` | `SIGUSR1` |
+| `reload` | `SIGHUP`  |
+| `ldm`    | `SIGUSR2` |
 
 ### Quit the server
 


### PR DESCRIPTION
While it is documented which signals cause which server behaviour, I had to look into the source code to find out [how the commands are mapped to signals](https://github.com/nats-io/nats-server/blob/ac23d77f49a4f80f98ea6ea56f8e42d09ac8fa77/server/signal.go#L144-L162). This PR documents the mapping.