### PR TITLE
Fixed duplicate word "to" and spacing after comma in stream description

### DIFF
--- a/nats-concepts/jetstream/source_and_mirror.md
+++ b/nats-concepts/jetstream/source_and_mirror.md
@@ -17,7 +17,7 @@ There are several options available when declaring the configuration.
 The stream using a source or mirror configuration can have its own retention policy, replication, and storage type.
 
 {% hint style="info" %}
-* Changes to to the stream using source or mirror,e.g. deleting messages or publishing, do not reflect back on the origin stream from which the data was received.
+* Changes to the stream using source or mirror, e.g. deleting messages or publishing, do not reflect back on the origin stream from which the data was received.
 * Deletes in the origin stream are NOT replicated through a `source` or `mirror` agreement.
 {% endhint %}
 

--- a/nats-concepts/jetstream/streams.md
+++ b/nats-concepts/jetstream/streams.md
@@ -165,7 +165,7 @@ Although less common, note that both the cluster _and_ tags can be used for plac
 
 When a stream is configured with a `source` or `mirror`, it will automatically and asynchronously replicate messages from the origin stream. There are several options when declaring the configuration.
 
-A source or mirror stream can have its own retention policy, replication, and storage type. Changes to to the source or mirror,e.g. deleting messages or publishing, do not reflect on the origin stream.
+A source or mirror stream can have its own retention policy, replication, and storage type. Changes to the source or mirror, e.g. deleting messages or publishing, do not reflect on the origin stream.
 
 
 {% hint style="info" %}


### PR DESCRIPTION
## Pull Request: Fix Typos in JetStream Documentation

This PR fixes small typos found in the JetStream documentation, specifically a duplicate word `"to to"` and a missing space after a comma in the explanation of source and mirror stream behavior.

---

### 📂 Changes Made

- **`nats-concepts/jetstream/source_and_mirror.md`**  
  - Removed duplicated word: `"to to"` ➝ `"to"`  
  - Fixed missing space after comma: `"mirror,e.g."` ➝ `"mirror, e.g."`

- **`nats-concepts/jetstream/streams.md`**  
  - Removed duplicated word: `"to to"` ➝ `"to"`  
  - Fixed missing space after comma: `"mirror,e.g."` ➝ `"mirror, e.g."`
