### PR TITLE
docs: link the jetstream cross-account use case

### DIFF
--- a/nats-concepts/jetstream/source_and_mirror.md
+++ b/nats-concepts/jetstream/source_and_mirror.md
@@ -3,7 +3,7 @@
 When a stream is configured with a `source` or `mirror`, it will automatically and asynchronously replicate messages from the origin stream. 
 
 `source` or `mirror` are designed to be robust and will recover from a loss of connection. They are suitable for geographic distribution over high latency and unreliable connections. E.g. even a leaf node starting and connecting intermittently every few days will still receive or send messages over the source/mirror link.
-
+Another use case is when [connecting streams cross-account](../../running-a-nats-service/configuration/securing_nats/accounts#exporting-and-importing-jetstream-streams-between-accounts).
 
 There are several options available when declaring the configuration.
 


### PR DESCRIPTION
I had a hard time finding information about how to handle Jetstreams cross account and had not looked into mirroring more since it seemed to be for high-latency connections and similar.

Adding a simple statement to help users in the right direction.