### PR TITLE
Clarify no_auth_user doesn't support bcrypted passwords

### DIFF
--- a/running-a-nats-service/configuration/securing_nats/accounts.md
+++ b/running-a-nats-service/configuration/securing_nats/accounts.md
@@ -193,7 +193,7 @@ no_auth_user: a
 
 The above example shows how clients without authentication can be associated with the user `a` within account `A`.
 
-> Please note that the `no_auth_user` will not work with nkeys. The user referenced can also be part of the [authorization](authorization.md) block.
+> Please note that the `no_auth_user` will not work with nkeys or bcrypted passwords. The user referenced can also be part of the [authorization](authorization.md) block.
 >
 > Despite `no_auth_user` being set, clients still need to communicate that they will not be using credentials. The [authentication timeout](auth_intro/auth_timeout.md) applies to this process as well. When your connection is slow, you may run into this timeout and the resulting `Authentication Timeout` error, despite not providing credentials.
 


### PR DESCRIPTION
Resolves https://github.com/nats-io/nats-server/issues/6928