### PR TITLE
kv.md: add example to get an existing bucket

### DIFF
--- a/using-nats/developing-with-nats/js/kv.md
+++ b/using-nats/developing-with-nats/js/kv.md
@@ -93,6 +93,17 @@ async def create_key_value(
     """
     create_key_value takes an api.KeyValueConfig and creates a KV in JetStream.
     """
+
+async def key_value(
+    self,
+    config: Optional[api.KeyValueConfig] = None,
+    **params,
+) -> KeyValue:
+    """
+    key_value retrieves the bucket with the passed name, if it exists
+    """
+
+
     
 async def delete_key_value(self, bucket: str) -> bool:
     """


### PR DESCRIPTION
It feels a bit strange that the command to retrieve an *existing* bucket is not mentioned in the Python example

Signed-off-by: Antonio Vivace <avivace4@gmail.com>
