### PR TITLE
Update example after fixing output in `stream copy`.

### DIFF
--- a/running-a-nats-service/nats_admin/jetstream_admin/streams.md
+++ b/running-a-nats-service/nats_admin/jetstream_admin/streams.md
@@ -145,7 +145,7 @@ A stream can be copied into another, which also allows the configuration of the 
 nats str cp ORDERS ARCHIVE --subjects "ORDERS_ARCHIVE.*" --max-age 2y
 ```
 ```text
-Stream ORDERS was created
+Stream ARCHIVE was created
 
 Information for Stream ORDERS created 2021-02-27T16:52:46-07:00
 


### PR DESCRIPTION
The message printed by `str cp old new` was `old was created`, while it should be `new was created`.

Reported in nats-io/natscli#1511, fixed in nats-io/natscli#1512

