### PR TITLE
Update installation.md: update ot on supported architectures

### DIFF
--- a/running-a-nats-service/installation.md
+++ b/running-a-nats-service/installation.md
@@ -13,18 +13,15 @@ See also [installing the NATS client](clients.md#installing-the-nats-cli-tool)
 
 ## Supported operating systems and architectures
 
-The following table indicates the current supported NATS server build combinations for operating systems and architectures.
+The NATS server officially supports the following platforms:
 
-| Operating System | Architectures                                  | Status       |
-| ---------------- | ---------------------------------------------- | ------------ |
-| Darwin (macOS)   | amd64, arm64                                   | Stable       |
-| Linux            | amd64, 386, arm6, arm7, arm64, mips64le, s390x | Stable       |
-| Windows          | amd64, 386, arm6, arm7, arm64                  | Stable       |
-| FreeBSD          | amd64                                          | Stable       |
-| NetBSD           | -                                              | Experimental |
-| IBM z/OS         | -                                              | Experimental |
+| Operating System | Architectures | Status |
+|------------------|---------------|--------|
+| Linux            | amd64, arm64  | Stable |
+| Darwin (macOS)   | arm64         | Stable |
+| Windows          | amd64, arm64  | Stable |
 
-_Note, not all installation methods below have distributions for all OS and architecture combinations._
+We build additional [OS/architecture combinations](https://github.com/nats-io/nats-server/releases) that are available on a best-effort, community-support basis.  
 
 ## Hardware requirements
 


### PR DESCRIPTION
I just saw the table is outdated, since we removed broken windows arm builds(https://github.com/nats-io/nats-server/pull/7309) added looong64(https://github.com/nats-io/nats-server/pull/7094), and thought maybe we just redirect people to GitHub releases, and not list all os/arch combinations here.