### PR TITLE
Warning about advisories in TLS config

### DIFF
--- a/running-a-nats-service/configuration/securing_nats/tls.md
+++ b/running-a-nats-service/configuration/securing_nats/tls.md
@@ -141,7 +141,7 @@ The issues and pitfalls listed here are not limited to self-signed certificates.
 
 NATS cluster advertises `host:port` of all nodes in a cluster to the connecting client. When connecting to a server via TLS the server name (or IP) is validated against the certificate presented by the server.
 
-When using TLS, it is important to set to control the hostname that clients will use when discovering the server since, by default, this will be an IP, otherwise TLS hostname verification may fail with an IP SANs error.
+When using TLS, it is important to control the hostname that clients will use when discovering the server. By default, the cluster will advertise an IP address, which may result in a failed TLS hostname verification with an IP SANs error.
 
 Set `avertise` or `cluster_advertise` in the cluster section to advertise verifiable server names. See [cluster_config.md](../clustering/cluster_config.md)
 


### PR DESCRIPTION
Warning in pitfalls about advisories. There is a section in cluster_config on this, but its easy to miss, So I replicated the warning and pointed to the pitfalls section on the top of the TLS section.