### PR TITLE
Add "At most once" to Kafka for Quality of Service Comparison

### DIFF
--- a/nats-concepts/overview/compare-nats.md
+++ b/nats-concepts/overview/compare-nats.md
@@ -34,7 +34,7 @@ In this comparison, we will be featuring NATS, Apache Kafka, RabbitMQ, Apache Pu
 | :--- | :--- |
 | **NATS** | At most once, at least once, and exactly once is available in JetStream. |
 | **gRPC** | At most once. |
-| **Kafka** | At least once, exactly once. |
+| **Kafka** | At most once, at least once, and exactly once. |
 | **Pulsar** | At most once, at least once, and exactly once. |
 | **Rabbit** | At most once, at least once. |
 


### PR DESCRIPTION
I believe Kafka producer client libraries have the option to not wait for any broker acknowledgement when publishing messages. This would satisfy an "at most once" delivery model.