### PR TITLE
Update JavaScript example to use timeout instead of reconnectTimeWait

### DIFF
--- a/using-nats/developing-with-nats/connecting/connect_timeout.md
+++ b/using-nats/developing-with-nats/connecting/connect_timeout.md
@@ -32,7 +32,7 @@ nc.close();
 {% tab title="JavaScript" %}
 ```javascript
 const nc = await connect({
-    reconnectTimeWait: 10 * 1000, // 10s
+    timeout: 10 * 1000, // 10s
     servers: ["demo.nats.io"],
 });
 ```


### PR DESCRIPTION
The documentation for the connect timeout suggests using `reconnectTimeWait` option, but the correct option should be `timeout`.