### PR TITLE
Fix invalid config for example source stream

### DIFF
--- a/nats-concepts/jetstream/source_and_mirror_example.md
+++ b/nats-concepts/jetstream/source_and_mirror_example.md
@@ -20,8 +20,8 @@ nats stream add --config stream_with_sources.json
   "duplicate_window": 120000000000,
   "sources": [
     {
-      "name": "SOURCE1_ORIGIN",
-    },
+      "name": "SOURCE1_ORIGIN"
+    }
   ],
   "deny_delete": false,
   "sealed": false,


### PR DESCRIPTION
The example source stream config was invalid because of trailing commas.