### PR TITLE
Fix missing .API in JetStream error-handling example

### DIFF
--- a/using-nats/jetstream/nats_api_reference.md
+++ b/using-nats/jetstream/nats_api_reference.md
@@ -27,10 +27,10 @@ Received  [_INBOX.lcWgjX2WgJLxqepU0K9pNf.mpBW9tHK] : {
 ```
 
 ```shell
-nats req '$JS.STREAM.INFO.ORDERS' ''
+nats req '$JS.API.STREAM.INFO.ORDERS' ''
 ```
 ```text
-Published 6 bytes to $JS.STREAM.INFO.ORDERS
+Published 6 bytes to $JS.API.STREAM.INFO.ORDERS
 Received  [_INBOX.fwqdpoWtG8XFXHKfqhQDVA.vBecyWmF] : '{
   "type": "io.nats.jetstream.api.v1.stream_info_response",
   "config": {


### PR DESCRIPTION
Fixes nats-io/nats.docs#889.

The second request/response example in the Error Handling section used `$JS.STREAM.INFO.ORDERS`.
That subject is missing `.API`; it should be `$JS.API.STREAM.INFO.ORDERS`.

This change updates both the request line and the corresponding `Published ... to` output.