### PR TITLE
msg_trace docs

### DIFF
--- a/nats-concepts/jetstream/headers.md
+++ b/nats-concepts/jetstream/headers.md
@@ -56,7 +56,7 @@ Introduced in version 2.11 - see [ADR-41](https://github.com/nats-io/nats-archit
 
 | Name            | Description                          | Example | Version |
 | :-------------- | :----------------------------------- | :------ | :------ |
-| `traceparent` | Triggers tracing as per the [https://www.w3.org/TR/trace-context/](https://www.w3.org/TR/trace-context/) standard. Requires the `msg-trace` section to be configured on the account level. | N/A | 2.11   |
+| `traceparent` | Triggers tracing as per the [https://www.w3.org/TR/trace-context/](https://www.w3.org/TR/trace-context/) standard. Requires tracing destination and sampling rate to be configured in the `msg_trace` section on the account level. See [Tracing open telemetry style](../../running-a-nats-service/configuration/README.md) | trace-ID-1234 | 2.11   |
 | `Nats-Trace-Dest` |  The subject that will receive the Trace messages  | trace.receiver.all | 2.11   |
 | `Nats-Trace-Only` | Optional. Defaults to `false`. Set to `true` to skip message delivery. If true only traces will be produced, but the messages is not sent to a subscribing client or stored in JetStream.   | `true` | 2.11   |
 | `Accept-Encoding` | Optional. Enables compression of the payload of the trace messages.  | `gzip`, `snappy` | 2.11   |

--- a/running-a-nats-service/configuration/README.md
+++ b/running-a-nats-service/configuration/README.md
@@ -375,11 +375,11 @@ jetstream {
 A JetStream section may also appear in accounts. JetStream is disabled by default. The minimal configuration will enable JetStream.
 ```text
 accounts {
-  A {}
-    jetstream {
-    }
-  } 
-
+  A {
+      jetstream {
+      }
+    } 
+}
 ```
 
 | Property                  | Description                                                                                                                                                                               | Default                 | Version |
@@ -393,6 +393,27 @@ accounts {
 | `store_max_stream_bytes`                     | Maximum size limit to which a disk stream can be set. Usually combined with `max_bytes_required`  | no limit  | 2.8.0  |
 | `memory_max_stream_bytes`                     |  Maximum size limit to which a memory stream can be set. Usually combined with `max_bytes_required`  | no limit  | 2.8.0  |
 | `cluster_traffic`                     |  `system` or `owner` Configures the account in which stream replication and RAFT traffic is sent. By default (and in all versions prior to 2.11.0) all cluster traffic was handled in the system account. When set to `owner`, such RAFT and replication traffic will be in the account where the stream was created. | `system`  | 2.11.0  |
+
+
+### Tracing open telemetry style 
+Enables tracing for messages marked with the `traceparent` header. 
+See also: [Tracing](../../nats-concepts/jetstream/headers.md)
+
+```text
+accounts {
+  A {
+      msg_trace {
+        dest: "trace-ot.accountA.samples"
+        sampling: 5
+      }
+    } 
+}
+```
+
+| Property                  | Description                                                                                                                                                                               | Default                 | Version |
+| :------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------- | :------ |
+| `dest`                     |  The tracing subject on which OT compliant messages will be sent. Tracing is disabled by default. | <empty>> | 2.2.0  |
+| `sampling`                     |  A value between 0 and 100 | no limit or server limit | 2.2.0  |
 
 
 ### JetStream TPM encryption


### PR DESCRIPTION
Documented msg_trace section in account. Fixed typos and cross referenced from headers documentation.