### PR TITLE
Added `max_payload` doc for Rust

### DIFF
--- a/using-nats/developing-with-nats/connecting/misc.md
+++ b/using-nats/developing-with-nats/connecting/misc.md
@@ -83,6 +83,13 @@ end
 ```
 {% endtab %}
 
+{% tab title="Rust" %}
+```rust
+let client = async_nats::connect("demo.nats.io").await?;
+println!("max payload: {:?}", client.max_payload());
+```
+{% endtab %}
+
 {% tab title="C" %}
 ```c
 natsConnection      *conn    = NULL;


### PR DESCRIPTION
The [Max Payload Docs](https://docs.nats.io/using-nats/developer/connecting/misc#get-the-maximum-payload-size) doesn't have a tab for Rust. Fortunately the [Async NATS crate docs](https://docs.rs/async-nats/0.49.1/async_nats/client/struct.Client.html#method.max_payload) example exists. I think the example should also exist in the docs.nats.io website. 